### PR TITLE
Leaderboard

### DIFF
--- a/RetroChess.pro
+++ b/RetroChess.pro
@@ -53,7 +53,8 @@ SOURCES = RetroChessPlugin.cpp               \
           gui/validation.cpp \
           gui/RetroChessChatWidgetHolder.cpp \
           gui/RetroChessSettings.cpp \
-          gui/RetroChessUserNotify.cpp
+          gui/RetroChessUserNotify.cpp \
+          gui/RetroChessLeaderboard.cpp
 
 HEADERS = RetroChessPlugin.h                 \
           services/p3RetroChess.h            \
@@ -66,7 +67,8 @@ HEADERS = RetroChessPlugin.h                 \
           gui/chess.h \
           gui/RetroChessChatWidgetHolder.h \
           gui/RetroChessSettings.h \
-          gui/RetroChessUserNotify.h
+          gui/RetroChessUserNotify.h \
+          gui/RetroChessLeaderboard.h
 
 FORMS += \
           gui/NEMainpage.ui \

--- a/gui/NEMainpage.cpp
+++ b/gui/NEMainpage.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <string>
 #include <QTime>
+#include <QDateTime>
 #include <QMenu>
 #include <QMessageBox>
 #include <QToolButton>
@@ -39,9 +40,12 @@
 
 #include "gui/RetroChessSettings.h"
 #include "gui/RetroChessUserNotify.h"
+#include "gui/RetroChessLeaderboard.h"
 
 #include "gui/chat/ChatDialog.h"
 #include <retroshare/rsidentity.h>
+#include <QTableWidget>
+#include <QVBoxLayout>
 
 
 NEMainpage::NEMainpage(QWidget *parent, RetroChessNotify *notify) :
@@ -50,9 +54,22 @@ NEMainpage::NEMainpage(QWidget *parent, RetroChessNotify *notify) :
 	mNotify(notify),
 	mOfficialLobbyTimer(new QTimer(this)),
 	mOfficialLobbyDialog(nullptr),
-	mLobbyUnreadCount(0)
+	mLobbyUnreadCount(0),
+	mLeaderboard(new RetroChessLeaderboard(this)),
+	mLeaderboardTable(new QTableWidget(this))
 {
 	ui->setupUi(this);
+	QWidget *leaderboardPage = new QWidget(ui->tabWidget);
+	QVBoxLayout *leaderboardLayout = new QVBoxLayout(leaderboardPage);
+	QLabel *leaderboardInfo = new QLabel(
+	        tr("Standard Glicko-2 rating. A game is counted after both players publish the same signed result."),
+	        leaderboardPage);
+	leaderboardInfo->setWordWrap(true);
+	leaderboardLayout->addWidget(leaderboardInfo);
+	leaderboardLayout->addWidget(mLeaderboardTable);
+	ui->tabWidget->insertTab(1, leaderboardPage, tr("Leaderboard"));
+	connect(mLeaderboard, SIGNAL(changed()), this, SLOT(refreshLeaderboard()));
+	refreshLeaderboard();
 	setupMenuActions();
 
 	connect(mNotify, SIGNAL(NeMsgArrived(RsPeerId,QString)), this, SLOT(NeMsgArrived(RsPeerId,QString)));
@@ -64,6 +81,8 @@ NEMainpage::NEMainpage(QWidget *parent, RetroChessNotify *notify) :
 	connect(mNotify, SIGNAL(chessPlayerLeftGxs(RsGxsId)), this, SLOT(chessPlayerLeftGxs(RsGxsId)));
 	connect(mNotify, SIGNAL(chessRematchGxs(RsGxsId,int)), this, SLOT(chessRematchGxs(RsGxsId,int)));
 	connect(mNotify, SIGNAL(chessGameActionGxs(RsGxsId,QString)), this, SLOT(chessGameActionGxs(RsGxsId,QString)));
+	connect(mNotify, SIGNAL(ratedResultGxs(RsGxsId,QString,RsGxsId,RsGxsId,QString,qint64)),
+	        this, SLOT(ratedResultGxs(RsGxsId,QString,RsGxsId,RsGxsId,QString,qint64)));
 
 	connect(mOfficialLobbyTimer, SIGNAL(timeout()), this, SLOT(autoJoinOfficialLobby()));
 	mOfficialLobbyTimer->setInterval(15000);
@@ -179,6 +198,11 @@ void NEMainpage::officialLobbyNewMessage(ChatWidget *)
 	emit lobbyUnreadCountChanged();
 }
 
+void NEMainpage::refreshLeaderboard()
+{
+	mLeaderboard->populate(mLeaderboardTable);
+}
+
 void NEMainpage::showEvent(QShowEvent *event)
 {
 	if (mLobbyUnreadCount) {
@@ -245,6 +269,7 @@ void NEMainpage::removeActiveGameListing(QString gameId)
 
 void NEMainpage::requestRematchGxs(const RsGxsId &gxs_id, int localColor)
 {
+	rsRetroChess->startNewGameIdForPeer(gxs_id);
 	if (!rsRetroChess->sendRematchGxs(gxs_id, localColor))
 		return;
 
@@ -282,6 +307,12 @@ void NEMainpage::chessGameActionGxs(const RsGxsId &gxs_id, QString action)
 	const std::string key = gxs_id.toStdString();
 	if (activeGames.contains(key))
 		activeGames.value(key)->applyGameAction(action, true);
+}
+
+void NEMainpage::ratedResultGxs(RsGxsId signer, QString gameId, RsGxsId white,
+	                            RsGxsId black, QString result, qint64 finishedAt)
+{
+	mLeaderboard->receiveResult(signer, gameId, white, black, result, finishedAt);
 }
 
 // decode received message here
@@ -428,6 +459,13 @@ void NEMainpage::create_chess_window_gxs(const RsGxsId &gxs_id, int player_id)
             this, SLOT(requestRematchGxs(RsGxsId,int)));
     connect(win, SIGNAL(gameClosed(QString)), this, SLOT(removeActiveGame(QString)));
     connect(win, SIGNAL(gameEnded(QString)), this, SLOT(removeActiveGameListing(QString)));
+    connect(win, &RetroChessWindow::ratedResult, this,
+            [this, gxs_id](const QString &gameId, const RsGxsId &white,
+                   const RsGxsId &black, const QString &result) {
+        mLeaderboard->submitResult(gameId, white, black, result);
+        rsRetroChess->sendRatedResultGxs(gxs_id, gameId, white, black, result,
+                                        QDateTime::currentSecsSinceEpoch());
+    });
     win->show();
 
     // Track the game so GXS moves can be routed to it

--- a/gui/NEMainpage.cpp
+++ b/gui/NEMainpage.cpp
@@ -56,16 +56,17 @@ NEMainpage::NEMainpage(QWidget *parent, RetroChessNotify *notify) :
 	mOfficialLobbyDialog(nullptr),
 	mLobbyUnreadCount(0),
 	mLeaderboard(new RetroChessLeaderboard(this)),
-	mLeaderboardTable(new QTableWidget(this))
+	mLeaderboardTable(new QTableWidget(this)),
+	mLeaderboardInfo(nullptr)
 {
 	ui->setupUi(this);
 	QWidget *leaderboardPage = new QWidget(ui->tabWidget);
 	QVBoxLayout *leaderboardLayout = new QVBoxLayout(leaderboardPage);
-	QLabel *leaderboardInfo = new QLabel(
+	mLeaderboardInfo = new QLabel(
 	        tr("Standard Glicko-2 rating. A game is counted after both players publish the same signed result."),
 	        leaderboardPage);
-	leaderboardInfo->setWordWrap(true);
-	leaderboardLayout->addWidget(leaderboardInfo);
+	mLeaderboardInfo->setWordWrap(true);
+	leaderboardLayout->addWidget(mLeaderboardInfo);
 	leaderboardLayout->addWidget(mLeaderboardTable);
 	ui->tabWidget->insertTab(1, leaderboardPage, tr("Leaderboard"));
 	connect(mLeaderboard, SIGNAL(changed()), this, SLOT(refreshLeaderboard()));
@@ -201,6 +202,11 @@ void NEMainpage::officialLobbyNewMessage(ChatWidget *)
 void NEMainpage::refreshLeaderboard()
 {
 	mLeaderboard->populate(mLeaderboardTable);
+	const RsGxsGroupId groupId = mLeaderboard->ledgerGroupId();
+	mLeaderboardInfo->setText(groupId.isNull()
+	        ? tr("Searching for the distributed RetroChess leaderboard GXS group…")
+	        : tr("Synchronized GXS ledger: %1 — games count after both signed results match.")
+	          .arg(QString::fromStdString(groupId.toStdString())));
 }
 
 void NEMainpage::showEvent(QShowEvent *event)

--- a/gui/NEMainpage.h
+++ b/gui/NEMainpage.h
@@ -44,6 +44,7 @@ class ChatWidget;
 class UserNotify;
 class QShowEvent;
 class QTableWidget;
+class QLabel;
 class RetroChessLeaderboard;
 
 namespace Ui
@@ -91,6 +92,7 @@ private:
 	unsigned int mLobbyUnreadCount;
 	RetroChessLeaderboard *mLeaderboard;
 	QTableWidget *mLeaderboardTable;
+	QLabel *mLeaderboardInfo;
 
 	QMap<std::string, RetroChessWindow*> activeGames;
 	void create_chess_window(std::string peer_id, int player_id);

--- a/gui/NEMainpage.h
+++ b/gui/NEMainpage.h
@@ -43,6 +43,8 @@ class ChatDialog;
 class ChatWidget;
 class UserNotify;
 class QShowEvent;
+class QTableWidget;
+class RetroChessLeaderboard;
 
 namespace Ui
 {
@@ -72,18 +74,23 @@ private slots:
 	void chessPlayerLeftGxs(const RsGxsId &gxs_id);
 	void chessRematchGxs(const RsGxsId &gxs_id, int remoteColor);
 	void chessGameActionGxs(const RsGxsId &gxs_id, QString action);
+	void ratedResultGxs(RsGxsId signer, QString gameId, RsGxsId white,
+	                    RsGxsId black, QString result, qint64 finishedAt);
 	void requestRematchGxs(const RsGxsId &gxs_id, int localColor);
 	void requestRematchPeer(QString peerId, int localColor);
 	void removeActiveGame(QString gameId);
 	void removeActiveGameListing(QString gameId);
 	void autoJoinOfficialLobby();
 	void officialLobbyNewMessage(ChatWidget *chatWidget);
+	void refreshLeaderboard();
 private:
 	Ui::NEMainpage *ui;
 	RetroChessNotify *mNotify;
 	QTimer *mOfficialLobbyTimer;
 	ChatDialog *mOfficialLobbyDialog;
 	unsigned int mLobbyUnreadCount;
+	RetroChessLeaderboard *mLeaderboard;
+	QTableWidget *mLeaderboardTable;
 
 	QMap<std::string, RetroChessWindow*> activeGames;
 	void create_chess_window(std::string peer_id, int player_id);

--- a/gui/RetroChessLeaderboard.cpp
+++ b/gui/RetroChessLeaderboard.cpp
@@ -1,0 +1,198 @@
+#include "RetroChessLeaderboard.h"
+
+#include <algorithm>
+#include <cmath>
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QTableWidget>
+#include <QHeaderView>
+#include <retroshare/rsidentity.h>
+#include "gui/settings/rsharesettings.h"
+
+namespace {
+constexpr double kScale = 173.7178;
+constexpr double kTau = 0.5;
+
+QString displayName(const RsGxsId &id)
+{
+	RsIdentityDetails details;
+	if (rsIdentity && rsIdentity->getIdDetails(id, details))
+		return QString::fromUtf8(details.mNickname.c_str());
+	return QString::fromStdString(id.toStdString()).left(12);
+}
+
+double newVolatility(double phi, double delta, double variance, double sigma)
+{
+	const double a = std::log(sigma * sigma);
+	auto f = [=](double x) {
+		const double ex = std::exp(x);
+		return ex * (delta * delta - phi * phi - variance - ex)
+		       / (2.0 * std::pow(phi * phi + variance + ex, 2.0)) - (x - a) / (kTau * kTau);
+	};
+	double A = a, B;
+	if (delta * delta > phi * phi + variance)
+		B = std::log(delta * delta - phi * phi - variance);
+	else {
+		int k = 1;
+		while (f(a - k * kTau) < 0.0) ++k;
+		B = a - k * kTau;
+	}
+	double fA = f(A), fB = f(B);
+	while (std::abs(B - A) > 0.000001) {
+		const double C = A + (A - B) * fA / (fB - fA);
+		const double fC = f(C);
+		if (fC * fB <= 0.0) { A = B; fA = fB; }
+		else fA /= 2.0;
+		B = C; fB = fC;
+	}
+	return std::exp(A / 2.0);
+}
+
+void updatePair(RetroChessLeaderboard::Player &a,
+	             RetroChessLeaderboard::Player &b, double scoreA)
+{
+	auto next = [](const RetroChessLeaderboard::Player &p,
+	               const RetroChessLeaderboard::Player &op, double score) {
+		RetroChessLeaderboard::Player n = p;
+		const double mu = (p.rating - 1500.0) / kScale;
+		const double phi = p.rd / kScale;
+		const double muJ = (op.rating - 1500.0) / kScale;
+		const double phiJ = op.rd / kScale;
+		const double g = 1.0 / std::sqrt(1.0 + 3.0 * phiJ * phiJ / (M_PI * M_PI));
+		const double e = 1.0 / (1.0 + std::exp(-g * (mu - muJ)));
+		const double variance = 1.0 / (g * g * e * (1.0 - e));
+		const double delta = variance * g * (score - e);
+		n.volatility = newVolatility(phi, delta, variance, p.volatility);
+		const double phiStar = std::sqrt(phi * phi + n.volatility * n.volatility);
+		const double phiPrime = 1.0 / std::sqrt(1.0 / (phiStar * phiStar) + 1.0 / variance);
+		const double muPrime = mu + phiPrime * phiPrime * g * (score - e);
+		n.rating = 1500.0 + kScale * muPrime;
+		n.rd = kScale * phiPrime;
+		return n;
+	};
+	const RetroChessLeaderboard::Player oldA = a, oldB = b;
+	a = next(oldA, oldB, scoreA);
+	b = next(oldB, oldA, 1.0 - scoreA);
+}
+}
+
+RetroChessLeaderboard::RetroChessLeaderboard(QObject *parent) : QObject(parent)
+{
+	load();
+}
+
+RetroChessLeaderboard::~RetroChessLeaderboard() = default;
+
+bool RetroChessLeaderboard::validResult(const QString &r)
+{ return r == "1-0" || r == "0-1" || r == "1/2-1/2"; }
+
+QString RetroChessLeaderboard::canonicalKey(const Receipt &r)
+{ return r.gameId + '|' + r.white + '|' + r.black + '|' + r.result; }
+
+void RetroChessLeaderboard::submitResult(const QString &gameId, const RsGxsId &white,
+	                                      const RsGxsId &black, const QString &result)
+{
+	if (gameId.isEmpty() || white.isNull() || black.isNull() || !validResult(result)) return;
+	Receipt r{gameId, QString::fromStdString(white.toStdString()),
+	          QString::fromStdString(black.toStdString()), result,
+	          QString::fromStdString((white == black ? RsGxsId() :
+	              (rsIdentity->isOwnId(white) ? white : black)).toStdString()),
+	          QDateTime::currentSecsSinceEpoch()};
+	if (r.signer.isEmpty()) return;
+	consumeReceipt(r);
+}
+
+void RetroChessLeaderboard::receiveResult(const RsGxsId &signer, const QString &gameId,
+	                                       const RsGxsId &white, const RsGxsId &black,
+	                                       const QString &result, qint64 finishedAt)
+{
+	consumeReceipt(Receipt{gameId, QString::fromStdString(white.toStdString()),
+	        QString::fromStdString(black.toStdString()), result,
+	        QString::fromStdString(signer.toStdString()), finishedAt});
+}
+
+void RetroChessLeaderboard::consumeReceipt(const Receipt &r)
+{
+	if (r.gameId.isEmpty() || r.white.isEmpty() || r.black.isEmpty() || !validResult(r.result)
+	    || (r.signer != r.white && r.signer != r.black)) return;
+	const QString key = canonicalKey(r) + '|' + r.signer;
+	if (mReceipts.contains(key)) return;
+	// A signer may confirm only one version of a game.
+	for (auto it = mReceipts.cbegin(); it != mReceipts.cend(); ++it)
+		if (it.value().gameId == r.gameId && it.value().signer == r.signer) return;
+	mReceipts.insert(key, r);
+	save(); recompute(); emit changed();
+}
+
+void RetroChessLeaderboard::recompute()
+{
+	mPlayers.clear();
+	QMap<QString, QList<Receipt>> byGame;
+	for (const Receipt &r : mReceipts) byGame[r.gameId].append(r);
+	QList<Receipt> confirmed;
+	for (const QList<Receipt> &list : byGame) {
+		if (list.size() < 2) continue;
+		for (const Receipt &a : list) for (const Receipt &b : list)
+			if (a.signer == a.white && b.signer == a.black && canonicalKey(a) == canonicalKey(b)) {
+				confirmed.append(a); goto nextGame;
+			}
+		nextGame:;
+	}
+	std::sort(confirmed.begin(), confirmed.end(), [](const Receipt &a, const Receipt &b) {
+		return a.finishedAt == b.finishedAt ? a.gameId < b.gameId : a.finishedAt < b.finishedAt;
+	});
+	for (const Receipt &r : confirmed) {
+		Player &w = mPlayers[r.white], &b = mPlayers[r.black];
+		w.id = RsGxsId(r.white.toStdString()); b.id = RsGxsId(r.black.toStdString());
+		w.name = displayName(w.id); b.name = displayName(b.id);
+		const double score = r.result == "1-0" ? 1.0 : (r.result == "0-1" ? 0.0 : 0.5);
+		updatePair(w, b, score);
+		if (score == 1.0) { ++w.wins; ++b.losses; }
+		else if (score == 0.0) { ++w.losses; ++b.wins; }
+		else { ++w.draws; ++b.draws; }
+		w.lastPlayed = b.lastPlayed = QDateTime::fromSecsSinceEpoch(r.finishedAt);
+	}
+}
+
+void RetroChessLeaderboard::populate(QTableWidget *table) const
+{
+	QList<Player> players = mPlayers.values();
+	std::sort(players.begin(), players.end(), [](const Player &a, const Player &b) { return a.rating > b.rating; });
+	table->setSortingEnabled(false); table->setRowCount(players.size()); table->setColumnCount(10);
+	table->setHorizontalHeaderLabels({tr("#"), tr("Player"), tr("Rating"), tr("RD"), tr("Games"),
+	                                  tr("W"), tr("D"), tr("L"), tr("Status"), tr("Last played")});
+	for (int row = 0; row < players.size(); ++row) {
+		const Player &p = players.at(row);
+		const QStringList values{QString::number(row + 1), p.name, QString::number(qRound(p.rating)),
+		                         QString::number(qRound(p.rd)), QString::number(p.games()),
+		                         QString::number(p.wins), QString::number(p.draws), QString::number(p.losses),
+		                         p.provisional() ? tr("Provisional") : tr("Rated"),
+		                         p.lastPlayed.toLocalTime().toString(Qt::DefaultLocaleShortDate)};
+		for (int col = 0; col < values.size(); ++col) table->setItem(row, col, new QTableWidgetItem(values.at(col)));
+	}
+	table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+	table->resizeColumnsToContents(); table->setSortingEnabled(true);
+}
+
+void RetroChessLeaderboard::load()
+{
+	const QByteArray raw = Settings->valueFromGroup("RetroChess", "LeaderboardReceipts").toByteArray();
+	const QJsonArray array = QJsonDocument::fromJson(raw).array();
+	for (const QJsonValue &v : array) {
+		const QJsonObject o = v.toObject();
+		Receipt r{o["game_id"].toString(), o["white"].toString(), o["black"].toString(),
+		          o["result"].toString(), o["signer"].toString(), static_cast<qint64>(o["finished_at"].toDouble())};
+		if (!r.gameId.isEmpty()) mReceipts.insert(canonicalKey(r) + '|' + r.signer, r);
+	}
+	recompute();
+}
+
+void RetroChessLeaderboard::save() const
+{
+	QJsonArray array;
+	for (const Receipt &r : mReceipts) array.append(QJsonObject{{"game_id",r.gameId},{"white",r.white},
+		{"black",r.black},{"result",r.result},{"signer",r.signer},{"finished_at",static_cast<double>(r.finishedAt)}});
+	Settings->setValueToGroup("RetroChess", "LeaderboardReceipts", QJsonDocument(array).toJson(QJsonDocument::Compact));
+	Settings->sync();
+}

--- a/gui/RetroChessLeaderboard.cpp
+++ b/gui/RetroChessLeaderboard.cpp
@@ -7,12 +7,17 @@
 #include <QJsonObject>
 #include <QTableWidget>
 #include <QHeaderView>
+#include <QTimer>
+#include <QSet>
 #include <retroshare/rsidentity.h>
+#include <retroshare/rsgxsforums.h>
 #include "gui/settings/rsharesettings.h"
 
 namespace {
 constexpr double kScale = 173.7178;
 constexpr double kTau = 0.5;
+const char kLedgerName[] = "RetroChess Leaderboard";
+const char kLedgerMarker[] = "Official distributed RetroChess rating ledger | retrochess:leaderboard:v1";
 
 QString displayName(const RsGxsId &id)
 {
@@ -77,9 +82,13 @@ void updatePair(RetroChessLeaderboard::Player &a,
 }
 }
 
-RetroChessLeaderboard::RetroChessLeaderboard(QObject *parent) : QObject(parent)
+RetroChessLeaderboard::RetroChessLeaderboard(QObject *parent) : QObject(parent), mSyncTimer(new QTimer(this))
 {
 	load();
+	connect(mSyncTimer, &QTimer::timeout, this, &RetroChessLeaderboard::synchronizeGxsLedger);
+	mSyncTimer->setInterval(15000);
+	mSyncTimer->start();
+	QTimer::singleShot(0, this, &RetroChessLeaderboard::synchronizeGxsLedger);
 }
 
 RetroChessLeaderboard::~RetroChessLeaderboard() = default;
@@ -101,6 +110,10 @@ void RetroChessLeaderboard::submitResult(const QString &gameId, const RsGxsId &w
 	          QDateTime::currentSecsSinceEpoch()};
 	if (r.signer.isEmpty()) return;
 	consumeReceipt(r);
+	if (!mLedgerGroupId.isNull() && publishReceipt(r)) {
+		mPublishedReceipts.insert(canonicalKey(r) + '|' + r.signer);
+		save();
+	}
 }
 
 void RetroChessLeaderboard::receiveResult(const RsGxsId &signer, const QString &gameId,
@@ -177,6 +190,11 @@ void RetroChessLeaderboard::populate(QTableWidget *table) const
 
 void RetroChessLeaderboard::load()
 {
+	mLedgerGroupId = RsGxsGroupId(Settings->valueFromGroup(
+	        "RetroChess", "LeaderboardGxsGroup").toString().toStdString());
+	const QStringList published = Settings->valueFromGroup(
+	        "RetroChess", "LeaderboardPublishedReceipts").toStringList();
+	mPublishedReceipts = QSet<QString>(published.cbegin(), published.cend());
 	const QByteArray raw = Settings->valueFromGroup("RetroChess", "LeaderboardReceipts").toByteArray();
 	const QJsonArray array = QJsonDocument::fromJson(raw).array();
 	for (const QJsonValue &v : array) {
@@ -194,5 +212,120 @@ void RetroChessLeaderboard::save() const
 	for (const Receipt &r : mReceipts) array.append(QJsonObject{{"game_id",r.gameId},{"white",r.white},
 		{"black",r.black},{"result",r.result},{"signer",r.signer},{"finished_at",static_cast<double>(r.finishedAt)}});
 	Settings->setValueToGroup("RetroChess", "LeaderboardReceipts", QJsonDocument(array).toJson(QJsonDocument::Compact));
+	Settings->setValueToGroup("RetroChess", "LeaderboardGxsGroup",
+	        QString::fromStdString(mLedgerGroupId.toStdString()));
+	Settings->setValueToGroup("RetroChess", "LeaderboardPublishedReceipts",
+	        QStringList(mPublishedReceipts.values()));
 	Settings->sync();
+}
+
+void RetroChessLeaderboard::synchronizeGxsLedger()
+{
+	if (!rsGxsForums || !rsIdentity) return;
+	// Keep discovering even after creation so independently created bootstrap
+	// groups converge on the lexicographically smallest valid protocol group.
+	selectOrCreateLedgerGroup();
+	if (mLedgerGroupId.isNull()) return;
+	rsGxsForums->subscribeToForum(mLedgerGroupId, true);
+	readLedgerPosts();
+	publishPendingReceipts();
+}
+
+void RetroChessLeaderboard::selectOrCreateLedgerGroup()
+{
+	std::list<RsGroupMetaData> summaries;
+	if (!rsGxsForums->getForumsSummaries(summaries)) return;
+	QList<RsGxsGroupId> candidates;
+	for (const RsGroupMetaData &meta : summaries)
+		if (meta.mGroupName == kLedgerName) candidates.append(meta.mGroupId);
+	if (!candidates.isEmpty()) {
+		std::sort(candidates.begin(), candidates.end(), [](const RsGxsGroupId &a, const RsGxsGroupId &b) {
+			return a.toStdString() < b.toStdString();
+		});
+		RsGxsGroupId selected;
+		for (const RsGxsGroupId &id : candidates) {
+			std::vector<RsGxsForumGroup> groups;
+			if (rsGxsForums->getForumsInfo({id}, groups) && !groups.empty()
+			    && groups.front().mDescription == kLedgerMarker) {
+				selected = id; break;
+			}
+		}
+		if (!selected.isNull()) {
+			if (selected != mLedgerGroupId) {
+				mLedgerGroupId = selected;
+				mPublishedReceipts.clear();
+				save();
+				emit changed();
+			}
+			return;
+		}
+	}
+	if (!mLedgerGroupId.isNull()) return;
+	// Wait for normal GXS discovery before creating, which avoids most duplicate groups.
+	if (++mDiscoveryAttempts < 3) return;
+	std::list<RsGxsId> ownIds;
+	rsIdentity->getOwnIds(ownIds);
+	RsGxsId author;
+	for (const RsGxsId &id : ownIds) {
+		RsIdentityDetails details;
+		if (rsIdentity->getIdDetails(id, details) && (details.mFlags & RS_IDENTITY_FLAGS_PGP_LINKED)) {
+			author = id; break;
+		}
+	}
+	if (author.isNull()) return;
+	RsGxsGroupId created;
+	std::string error;
+	if (rsGxsForums->createForumV2(kLedgerName, kLedgerMarker, author, {},
+	        RsGxsCircleType::PUBLIC, RsGxsCircleId(), created, error)) {
+		mLedgerGroupId = created;
+		rsGxsForums->subscribeToForum(created, true);
+		save();
+		emit changed();
+	}
+}
+
+void RetroChessLeaderboard::readLedgerPosts()
+{
+	std::vector<RsMsgMetaData> metas;
+	if (!rsGxsForums->getForumMsgMetaData(mLedgerGroupId, metas)) return;
+	std::set<RsGxsMessageId> ids;
+	for (const RsMsgMetaData &meta : metas) ids.insert(meta.mMsgId);
+	if (ids.empty()) return;
+	std::vector<RsGxsForumMsg> posts;
+	if (!rsGxsForums->getForumContent(mLedgerGroupId, ids, posts)) return;
+	for (const RsGxsForumMsg &post : posts) {
+		const QJsonObject o = QJsonDocument::fromJson(QByteArray::fromStdString(post.mMsg)).object();
+		if (o.value("type").toString() != "retrochess_result_v1") continue;
+		receiveResult(post.mMeta.mAuthorId, o.value("game_id").toString(),
+		        RsGxsId(o.value("white").toString().toStdString()),
+		        RsGxsId(o.value("black").toString().toStdString()),
+		        o.value("result").toString(), static_cast<qint64>(o.value("finished_at").toDouble()));
+	}
+	std::vector<RsGxsMessageId> readIds(ids.begin(), ids.end());
+	rsGxsForums->markRead(mLedgerGroupId, readIds, true);
+}
+
+bool RetroChessLeaderboard::publishReceipt(const Receipt &r)
+{
+	if (mLedgerGroupId.isNull()) return false;
+	QJsonObject o{{"type","retrochess_result_v1"},{"version",1},{"game_id",r.gameId},
+	              {"white",r.white},{"black",r.black},{"result",r.result},
+	              {"finished_at",static_cast<double>(r.finishedAt)}};
+	RsGxsMessageId postId;
+	std::string error;
+	return rsGxsForums->createPost(mLedgerGroupId, "RetroChess result " + r.gameId.toStdString(),
+	        QJsonDocument(o).toJson(QJsonDocument::Compact).toStdString(),
+	        RsGxsId(r.signer.toStdString()), RsGxsMessageId(), RsGxsMessageId(), postId, error);
+}
+
+void RetroChessLeaderboard::publishPendingReceipts()
+{
+	for (const Receipt &r : mReceipts) {
+		const QString key = canonicalKey(r) + '|' + r.signer;
+		if (mPublishedReceipts.contains(key)) continue;
+		const RsGxsId signer(r.signer.toStdString());
+		if (!rsIdentity->isOwnId(signer)) continue;
+		if (publishReceipt(r)) mPublishedReceipts.insert(key);
+	}
+	save();
 }

--- a/gui/RetroChessLeaderboard.h
+++ b/gui/RetroChessLeaderboard.h
@@ -3,10 +3,12 @@
 #include <QObject>
 #include <QDateTime>
 #include <QMap>
+#include <QSet>
 #include <QString>
 #include <retroshare/rstypes.h>
 
 class QTableWidget;
+class QTimer;
 struct ChatMessage;
 
 class RetroChessLeaderboard : public QObject
@@ -33,6 +35,7 @@ public:
 	                   const RsGxsId &white, const RsGxsId &black,
 	                   const QString &result, qint64 finishedAt);
 	void populate(QTableWidget *table) const;
+	RsGxsGroupId ledgerGroupId() const { return mLedgerGroupId; }
 
 signals:
 	void changed();
@@ -46,9 +49,18 @@ private:
 	void recompute();
 	void load();
 	void save() const;
+	void synchronizeGxsLedger();
+	void selectOrCreateLedgerGroup();
+	void readLedgerPosts();
+	void publishPendingReceipts();
+	bool publishReceipt(const Receipt &receipt);
 	static QString canonicalKey(const Receipt &r);
 	static bool validResult(const QString &result);
 
 	QMap<QString, Receipt> mReceipts;
 	QMap<QString, Player> mPlayers;
+	RsGxsGroupId mLedgerGroupId;
+	QSet<QString> mPublishedReceipts;
+	QTimer *mSyncTimer;
+	int mDiscoveryAttempts = 0;
 };

--- a/gui/RetroChessLeaderboard.h
+++ b/gui/RetroChessLeaderboard.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <QObject>
+#include <QDateTime>
+#include <QMap>
+#include <QString>
+#include <retroshare/rstypes.h>
+
+class QTableWidget;
+struct ChatMessage;
+
+class RetroChessLeaderboard : public QObject
+{
+	Q_OBJECT
+public:
+	struct Player {
+		RsGxsId id;
+		QString name;
+		double rating = 1500.0;
+		double rd = 350.0;
+		double volatility = 0.06;
+		int wins = 0, draws = 0, losses = 0;
+		QDateTime lastPlayed;
+		int games() const { return wins + draws + losses; }
+		bool provisional() const { return games() < 10 || rd > 110.0; }
+	};
+
+	explicit RetroChessLeaderboard(QObject *parent = nullptr);
+	~RetroChessLeaderboard() override;
+	void submitResult(const QString &gameId, const RsGxsId &white,
+	                  const RsGxsId &black, const QString &result);
+	void receiveResult(const RsGxsId &signer, const QString &gameId,
+	                   const RsGxsId &white, const RsGxsId &black,
+	                   const QString &result, qint64 finishedAt);
+	void populate(QTableWidget *table) const;
+
+signals:
+	void changed();
+
+private:
+	struct Receipt {
+		QString gameId, white, black, result, signer;
+		qint64 finishedAt = 0;
+	};
+	void consumeReceipt(const Receipt &receipt);
+	void recompute();
+	void load();
+	void save() const;
+	static QString canonicalKey(const Receipt &r);
+	static bool validResult(const QString &result);
+
+	QMap<QString, Receipt> mReceipts;
+	QMap<QString, Player> mPlayers;
+};

--- a/gui/RetroChessNotify.cpp
+++ b/gui/RetroChessNotify.cpp
@@ -92,6 +92,13 @@ void RetroChessNotify::notifyChessGameActionGxs(const RsGxsId &gxs_id, QString a
 	emit chessGameActionGxs(gxs_id, action);
 }
 
+void RetroChessNotify::notifyRatedResultGxs(const RsGxsId &signer, QString gameId,
+	                                         RsGxsId white, RsGxsId black,
+	                                         QString result, qint64 finishedAt)
+{
+	emit ratedResultGxs(signer, gameId, white, black, result, finishedAt);
+}
+
 void RetroChessNotify::notifyChessStartGxs(const RsGxsId &gxs_id)
 {
 	emit chessStartGxs(gxs_id);

--- a/gui/RetroChessNotify.h
+++ b/gui/RetroChessNotify.h
@@ -56,6 +56,9 @@ public:
 	void notifyChessPlayerLeftGxs(const RsGxsId &gxs_id);
 	void notifyChessRematchGxs(const RsGxsId &gxs_id, int remoteColor);
 	void notifyChessGameActionGxs(const RsGxsId &gxs_id, QString action);
+	void notifyRatedResultGxs(const RsGxsId &signer, QString gameId,
+	                          RsGxsId white, RsGxsId black, QString result,
+	                          qint64 finishedAt);
 
 	void notifyChessStartGxs(const RsGxsId &gxs_id); 
 
@@ -72,6 +75,8 @@ signals:
 	void chessPlayerLeftGxs(const RsGxsId &gxs_id);
 	void chessRematchGxs(const RsGxsId &gxs_id, int remoteColor);
 	void chessGameActionGxs(const RsGxsId &gxs_id, QString action);
+	void ratedResultGxs(RsGxsId signer, QString gameId, RsGxsId white,
+	                    RsGxsId black, QString result, qint64 finishedAt);
 
 	void chessInvitedGxs(const RsGxsId &gxs_id);
 	void chessStartGxs(const RsGxsId &gxs_id);

--- a/gui/chess.cpp
+++ b/gui/chess.cpp
@@ -47,6 +47,7 @@ RetroChessWindow::RetroChessWindow(const RsGxsId &gxsId, int player, QWidget *pa
     m_suppressLeave(false),
     m_resultPopupShown(false),
     m_rematchRequested(false),
+    m_resultSubmitted(false),
     m_capturedBlackLabel(nullptr),
     m_capturedWhiteLabel(nullptr),
     m_moveTable(nullptr),
@@ -65,6 +66,7 @@ RetroChessWindow::RetroChessWindow(const RsGxsId &gxsId, int player, QWidget *pa
     setAttribute(Qt::WA_DeleteOnClose);
     mPeerId = gxsId.toStdString(); // Use string representation for internal tracking
 	mOwnGxsId = rsRetroChess->ownGxsIdForPeer(gxsId);
+	mGameId = rsRetroChess->gameIdForPeer(gxsId);
 
     m_ui->m_player1_result->hide();
     m_ui->m_player2_result->hide();
@@ -128,6 +130,7 @@ RetroChessWindow::RetroChessWindow(std::string peerid, int player, QWidget *pare
 	m_suppressLeave(false),
 	m_resultPopupShown(false),
 	m_rematchRequested(false),
+	m_resultSubmitted(false),
 	m_capturedBlackLabel(nullptr),
 	m_capturedWhiteLabel(nullptr),
 	m_moveTable(nullptr),
@@ -392,6 +395,7 @@ void RetroChessWindow::closeEvent(QCloseEvent *event)
 {
     // send leave message
     if (!m_suppressLeave && mIsGxs) {
+        submitRatedResult(false);
         rsRetroChess->player_leave_gxs(this->mGxsId);
     } else if (!m_suppressLeave) {
         rsRetroChess->player_leave(mPeerId);
@@ -1437,11 +1441,13 @@ void RetroChessWindow::applyGameAction(const QString &action, bool remote)
 		m_flag_finished = 1;
 		m_suppressLeave = true;
 		showGameResultDialog(remote);
+		submitRatedResult(remote);
 		emit gameEnded(QString::fromStdString(mPeerId));
 	} else if (action == "draw_accept") {
 		m_flag_finished = 1;
 		m_suppressLeave = true;
 		showGameResultDialog(false, true);
+		submitRatedResult(false, true);
 		emit gameEnded(QString::fromStdString(mPeerId));
 	}
 }
@@ -1505,6 +1511,7 @@ int RetroChessWindow::resultJudge()
         m_ui->m_player1_result->setVisible(true);
         m_ui->m_player2_result->setVisible(true);
         showGameResultDialog(m_localplayer_turn == 0);
+        submitRatedResult(m_localplayer_turn == 0);
         return 1;
     }
     else if( flag_black_king_alive == false)
@@ -1518,6 +1525,7 @@ int RetroChessWindow::resultJudge()
         m_ui->m_player1_result->setVisible(true);
         m_ui->m_player2_result->setVisible(true);
         showGameResultDialog(m_localplayer_turn == 1);
+        submitRatedResult(m_localplayer_turn == 1);
         return 2;
     }
     else
@@ -1528,6 +1536,7 @@ void RetroChessWindow::showPlayerLeaveMsg()
 {
 	// Stop all local interaction as soon as the opponent leaves.
 	m_flag_finished = 1;
+	submitRatedResult(true);
     QString name;
     if (mIsGxs) {
         // Resolve GXS nickname
@@ -1545,6 +1554,18 @@ void RetroChessWindow::showPlayerLeaveMsg()
     QString status_msg = name + tr(" has left");
     m_ui->m_status_bar->setText(status_msg);
     m_ui->m_status_bar->setVisible(true);
+}
+
+void RetroChessWindow::submitRatedResult(bool localWon, bool draw)
+{
+	if (!mIsGxs || m_resultSubmitted || mGameId.isEmpty() || mOwnGxsId.isNull()) return;
+	m_resultSubmitted = true;
+	const bool localIsWhite = m_localplayer_turn == 1;
+	const RsGxsId white = localIsWhite ? mOwnGxsId : mGxsId;
+	const RsGxsId black = localIsWhite ? mGxsId : mOwnGxsId;
+	QString result = "1/2-1/2";
+	if (!draw) result = (localWon == localIsWhite) ? "1-0" : "0-1";
+	emit ratedResult(mGameId, white, black, result);
 }
 
 void RetroChessWindow::playerTurnNotice()

--- a/gui/chess.h
+++ b/gui/chess.h
@@ -72,6 +72,8 @@ public:
 	bool m_suppressLeave;
 	bool m_resultPopupShown;
 	bool m_rematchRequested;
+	bool m_resultSubmitted;
+	QString mGameId;
 
 	//from global
 
@@ -128,12 +130,14 @@ public:
     void playerTurnNotice();
 	void closeForRematch();
 	void showGameResultDialog(bool localWon, bool draw = false);
+	void submitRatedResult(bool localWon, bool draw = false);
 
 signals:
 	void rematchRequested(const RsGxsId &gxsId, int localColor);
 	void rematchRequestedPeer(QString peerId, int localColor);
 	void gameClosed(QString gameId);
 	void gameEnded(QString gameId);
+	void ratedResult(QString gameId, RsGxsId white, RsGxsId black, QString result);
 };
 
 

--- a/interface/rsRetroChess.h
+++ b/interface/rsRetroChess.h
@@ -65,8 +65,13 @@ class RsRetroChess
 	virtual void acceptedInviteGxs(const RsGxsId &gxsId) = 0;
 	virtual bool hasInviteFromGxs(const RsGxsId &gxsId) = 0;
 	virtual RsGxsId ownGxsIdForPeer(const RsGxsId &gxsId) = 0;
+	virtual QString gameIdForPeer(const RsGxsId &gxsId) = 0;
+	virtual void startNewGameIdForPeer(const RsGxsId &gxsId) = 0;
 	virtual bool sendRematchGxs(const RsGxsId &gxsId, int localColor) = 0;
 	virtual bool sendGameActionGxs(const RsGxsId &gxsId, const std::string &action) = 0;
+	virtual bool sendRatedResultGxs(const RsGxsId &gxsId, const QString &gameId,
+	                                const RsGxsId &white, const RsGxsId &black,
+	                                const QString &result, qint64 finishedAt) = 0;
 
 	// Send invite via an *existing* distant chat tunnel (the right approach for distant chat)
 	virtual bool sendInvite_chat(const ChatId &chatId) = 0;

--- a/services/p3RetroChess.cc
+++ b/services/p3RetroChess.cc
@@ -28,6 +28,7 @@
 //#include "retroshare/rsmsgs.h"
 
 #include <sstream> // for std::istringstream
+#include <QUuid>
 
 #include "services/p3RetroChess.h"
 #include "services/rsRetroChessItems.h"
@@ -480,14 +481,20 @@ void p3RetroChess::acceptedInviteGxs(const RsGxsId &gxsId)
     if (it != mActiveTunnels.end()) {
         // Tunnel already active (server side — invite arrived over it).
         // Send chess_accept immediately.
-        std::string accept = "{\"type\":\"chess_accept\"}";
+        QVariantMap acceptMap;
+        acceptMap.insert("type", "chess_accept");
+        acceptMap.insert("game_id", mGameIdByPeer[gxsId]);
+        const std::string accept = QJsonDocument::fromVariant(acceptMap).toJson(QJsonDocument::Compact).toStdString();
         std::cout << "Chess: Sending chess_accept over tunnel " << it->second << std::endl;
         mGxsTunnels->sendData(it->second, RETRO_CHESS_GXS_TUNNEL_SERVICE_ID,
                               (const uint8_t*)accept.c_str(), accept.size());
     } else {
         // Client side: we initiated the invite but tunnel isn't in mActiveTunnels yet.
         // Queue accept for when tunnel becomes CAN_TALK.
-        mPendingGxsInvites[gxsId] = "{\"type\":\"chess_accept\"}";
+        QVariantMap acceptMap;
+        acceptMap.insert("type", "chess_accept");
+        acceptMap.insert("game_id", mGameIdByPeer[gxsId]);
+        mPendingGxsInvites[gxsId] = QJsonDocument::fromVariant(acceptMap).toJson(QJsonDocument::Compact).toStdString();
         requestGxsTunnel(gxsId);
     }
 }
@@ -503,8 +510,11 @@ bool p3RetroChess::sendRematchGxs(const RsGxsId &gxsId, int localColor)
         tunnelId = it->second;
     }
 
-    const std::string message = QString("{\"type\":\"rematch\",\"color\":%1}")
-            .arg(localColor).toStdString();
+    QVariantMap map;
+    map.insert("type", "rematch");
+    map.insert("color", localColor);
+    map.insert("game_id", gameIdForPeer(gxsId));
+    const std::string message = QJsonDocument::fromVariant(map).toJson(QJsonDocument::Compact).toStdString();
     return mGxsTunnels->sendData(
             tunnelId, RETRO_CHESS_GXS_TUNNEL_SERVICE_ID,
             reinterpret_cast<const uint8_t*>(message.data()), message.size());
@@ -529,6 +539,29 @@ bool p3RetroChess::sendGameActionGxs(const RsGxsId &gxsId, const std::string &ac
             reinterpret_cast<const uint8_t*>(message.constData()), message.size());
 }
 
+bool p3RetroChess::sendRatedResultGxs(const RsGxsId &gxsId, const QString &gameId,
+                                     const RsGxsId &white, const RsGxsId &black,
+                                     const QString &result, qint64 finishedAt)
+{
+    RsGxsTunnelId tunnelId;
+    {
+        RsStackMutex stack(mRetroChessMtx);
+        auto it = mActiveTunnels.find(gxsId);
+        if (it == mActiveTunnels.end() || !mGxsTunnels) return false;
+        tunnelId = it->second;
+    }
+    QVariantMap map;
+    map.insert("type", "rated_result");
+    map.insert("game_id", gameId);
+    map.insert("white", QString::fromStdString(white.toStdString()));
+    map.insert("black", QString::fromStdString(black.toStdString()));
+    map.insert("result", result);
+    map.insert("finished_at", finishedAt);
+    const QByteArray message = QJsonDocument::fromVariant(map).toJson(QJsonDocument::Compact);
+    return mGxsTunnels->sendData(tunnelId, RETRO_CHESS_GXS_TUNNEL_SERVICE_ID,
+            reinterpret_cast<const uint8_t*>(message.constData()), message.size());
+}
+
 bool p3RetroChess::hasInviteFromGxs(const RsGxsId &gxsId)
 {
     RsStackMutex stack(mRetroChessMtx);
@@ -540,6 +573,19 @@ RsGxsId p3RetroChess::ownGxsIdForPeer(const RsGxsId &gxsId)
     RsStackMutex stack(mRetroChessMtx);
     auto it = mOwnGxsIdByPeer.find(gxsId);
     return it == mOwnGxsIdByPeer.end() ? RsGxsId() : it->second;
+}
+
+QString p3RetroChess::gameIdForPeer(const RsGxsId &gxsId)
+{
+    RsStackMutex stack(mRetroChessMtx);
+    auto it = mGameIdByPeer.find(gxsId);
+    return it == mGameIdByPeer.end() ? QString() : it->second;
+}
+
+void p3RetroChess::startNewGameIdForPeer(const RsGxsId &gxsId)
+{
+    RsStackMutex stack(mRetroChessMtx);
+    mGameIdByPeer[gxsId] = QUuid::createUuid().toString(QUuid::WithoutBraces);
 }
 
 bool p3RetroChess::sendInvite_chat(const ChatId &chatId)
@@ -586,12 +632,18 @@ bool p3RetroChess::doSendInviteOverGxs(const RsGxsId &toId, const RsGxsId &ownId
     {
         RsStackMutex stack(mRetroChessMtx);
         mOwnGxsIdByPeer[toId] = ownId;
+        const QString gameId = QUuid::createUuid().toString(QUuid::WithoutBraces);
+        mGameIdByPeer[toId] = gameId;
+        QVariantMap inviteMap;
+        inviteMap.insert("type", "chess_invite");
+        inviteMap.insert("game_id", gameId);
+        const std::string invite = QJsonDocument::fromVariant(inviteMap).toJson(QJsonDocument::Compact).toStdString();
         auto activeIt = mActiveTunnels.find(toId);
         if (activeIt != mActiveTunnels.end()) {
-            const std::string invite = "{\"type\":\"chess_invite\"}";
             return mGxsTunnels->sendData(activeIt->second, RETRO_CHESS_GXS_TUNNEL_SERVICE_ID,
                                          (const uint8_t*)invite.c_str(), invite.size());
         }
+        mPendingGxsInvites[toId] = invite;
     }
 
     {
@@ -606,7 +658,6 @@ bool p3RetroChess::doSendInviteOverGxs(const RsGxsId &toId, const RsGxsId &ownId
     {
         RsStackMutex stack(mRetroChessMtx);
         mPendingTunnels[toId] = tunnelId;
-        mPendingGxsInvites[toId] = "{\"type\":\"chess_invite\"}";
         std::cout << "Chess: Tunnel requested (id=" << tunnelId << "), invite queued for " << toId << std::endl;
         return true;
     } else {
@@ -729,6 +780,9 @@ void p3RetroChess::handleRawData(const RsGxsId& gxs_id,
             RsStackMutex stack(mRetroChessMtx);
             // Remember this tunnel is active for the sender (server-side)
             mActiveTunnels[sender_id] = tunnel_id;
+            QString gameId = map.value("game_id").toString();
+            if (gameId.isEmpty()) gameId = QUuid::createUuid().toString(QUuid::WithoutBraces);
+            mGameIdByPeer[sender_id] = gameId;
             isNewInvite = mInvitesFromGxs.insert(sender_id).second;
         }
         if (isNewInvite)
@@ -739,6 +793,11 @@ void p3RetroChess::handleRawData(const RsGxsId& gxs_id,
 
     } else if (type == "chess_accept") {
         std::cout << "Chess: Received accept from GXS " << sender_id << std::endl;
+        {
+            RsStackMutex stack(mRetroChessMtx);
+            const QString gameId = map.value("game_id").toString();
+            if (!gameId.isEmpty()) mGameIdByPeer[sender_id] = gameId;
+        }
         mNotify->notifyChessAcceptedGxs(sender_id);
 
     } else if (type == "player_leave") {
@@ -747,11 +806,24 @@ void p3RetroChess::handleRawData(const RsGxsId& gxs_id,
 
     } else if (type == "rematch") {
         const int remoteColor = map.value("color").toInt();
+        {
+            RsStackMutex stack(mRetroChessMtx);
+            const QString remoteGameId = map.value("game_id").toString();
+            QString &localGameId = mGameIdByPeer[sender_id];
+            if (!remoteGameId.isEmpty() && (localGameId.isEmpty() || remoteGameId < localGameId))
+                localGameId = remoteGameId;
+        }
         std::cout << "Chess: Remote GXS player requested a rematch " << sender_id << std::endl;
         mNotify->notifyChessRematchGxs(sender_id, remoteColor);
 
     } else if (type == "game_action") {
         mNotify->notifyChessGameActionGxs(sender_id, map.value("action").toString());
+
+    } else if (type == "rated_result") {
+        mNotify->notifyRatedResultGxs(sender_id, map.value("game_id").toString(),
+                RsGxsId(map.value("white").toString().toStdString()),
+                RsGxsId(map.value("black").toString().toStdString()),
+                map.value("result").toString(), map.value("finished_at").toLongLong());
 
     } else {
         // Chess move: format "col,row,count"

--- a/services/p3RetroChess.h
+++ b/services/p3RetroChess.h
@@ -114,8 +114,13 @@ public:
 	void acceptedInviteGxs(const RsGxsId &gxsId);
 	bool hasInviteFromGxs(const RsGxsId &gxsId) override;
 	RsGxsId ownGxsIdForPeer(const RsGxsId &gxsId) override;
+	QString gameIdForPeer(const RsGxsId &gxsId) override;
+	void startNewGameIdForPeer(const RsGxsId &gxsId) override;
 	bool sendRematchGxs(const RsGxsId &gxsId, int localColor) override;
 	bool sendGameActionGxs(const RsGxsId &gxsId, const std::string &action) override;
+	bool sendRatedResultGxs(const RsGxsId &gxsId, const QString &gameId,
+	                        const RsGxsId &white, const RsGxsId &black,
+	                        const QString &result, qint64 finishedAt) override;
 	void chess_click_gxs(const RsGxsId &gxs_id, int col, int row, int count);
 	virtual void requestGxsTunnel(const RsGxsId &gxsId) override;
 
@@ -160,6 +165,7 @@ private:
 	std::map<RsGxsTunnelId, RsGxsId> mTunnelToGxsIdMap;
 	// Exact local identity used to communicate with each remote GXS identity.
 	std::map<RsGxsId, RsGxsId> mOwnGxsIdByPeer;
+	std::map<RsGxsId, QString> mGameIdByPeer;
 	// Leave messages get a short delivery window before their tunnel is closed.
 	std::map<RsGxsId, time_t> mPendingGxsCloses;
 	// DistantChatIds for which sendInvite_chat() was called but getDistantChatStatus()


### PR DESCRIPTION
Added:
- Standard Glicko‑2 ratings starting at 1500
- Ratings keyed by RsGxsId
- Unique game IDs, including rematches
- Signed result confirmation from both players
- Duplicate/conflicting result protection
- Persistent local leaderboard data
- Wins, draws, losses, games, rating, RD and last activity
- Provisional status for fewer than 10 games or RD above 110
- New Leaderboard tab in RetroChess

<img width="736" height="397" alt="image" src="https://github.com/user-attachments/assets/bb4c53d6-7b02-4c66-a09a-404b0962ac29" />
