### PR TITLE
CMake build + Qt6 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,15 +98,20 @@ if(RS_DEVELOPMENT_BUILD)
     )
 endif()
 
+# Resolve the RetroShare super-project root so this file works both from the
+# super-project (add_subdirectory) and standalone (cmake run in this dir),
+# as long as the plugin lives in <root>/plugins/RetroChess.
+get_filename_component(RS_SUPERPROJECT_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../.." ABSOLUTE)
+
 target_include_directories(RetroChess PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/gui
     ${CMAKE_CURRENT_SOURCE_DIR}/services
     ${CMAKE_CURRENT_SOURCE_DIR}/interface
-    ${CMAKE_SOURCE_DIR}/libretroshare/src
-    ${CMAKE_SOURCE_DIR}/retroshare-gui/src
-    ${CMAKE_SOURCE_DIR}/retroshare-gui/src/gui
-    ${CMAKE_SOURCE_DIR}/supportlibs/rapidjson/include
+    ${RS_SUPERPROJECT_ROOT}/libretroshare/src
+    ${RS_SUPERPROJECT_ROOT}/retroshare-gui/src
+    ${RS_SUPERPROJECT_ROOT}/retroshare-gui/src/gui
+    ${RS_SUPERPROJECT_ROOT}/supportlibs/rapidjson/include
 )
 
 install(TARGETS RetroChess DESTINATION lib/retroshare/plugins)

--- a/gui/NEMainpage.cpp
+++ b/gui/NEMainpage.cpp
@@ -37,6 +37,7 @@
 #include <QTimer>
 #include <QShowEvent>
 #include <QDateTime>
+#include <QLocale>
 #include <QHeaderView>
 #include <QHBoxLayout>
 #include <QPushButton>
@@ -262,7 +263,7 @@ void NEMainpage::addGxsInvitation(const RsGxsId &gxs_id)
 	identityFont.setPointSize(qMax(identityFont.pointSize() + 4, 18));
 	item->setFont(0, identityFont);
 	item->setId(gxs_id, 0, true);
-	item->setText(1, QDateTime::currentDateTime().toString(Qt::DefaultLocaleShortDate));
+	item->setText(1, QLocale().toString(QDateTime::currentDateTime(), QLocale::ShortFormat));
 	item->setSizeHint(0, QSize(44, 48));
 
 	QWidget *actions = new QWidget(ui->pendingInvites);

--- a/gui/chess.cpp
+++ b/gui/chess.cpp
@@ -26,6 +26,9 @@
 #include <QHeaderView>
 #include <QTableWidget>
 #include <QMediaPlayer>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QAudioOutput>
+#endif
 #include <QMessageBox>
 #include <QComboBox>
 #include <QDialogButtonBox>
@@ -386,12 +389,24 @@ void RetroChessWindow::initAccessories()
 	m_moveSound = new QMediaPlayer(this);
 	m_captureSound = new QMediaPlayer(this);
 	m_victorySound = new QMediaPlayer(this);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	m_moveSound->setAudioOutput(new QAudioOutput(m_moveSound));
+	m_captureSound->setAudioOutput(new QAudioOutput(m_captureSound));
+	m_victorySound->setAudioOutput(new QAudioOutput(m_victorySound));
+	m_moveSound->setSource(QUrl("qrc:/sound/Move.mp3"));
+	m_captureSound->setSource(QUrl("qrc:/sound/Capture.mp3"));
+	m_victorySound->setSource(QUrl("qrc:/sound/victory.mp3"));
+	m_moveSound->audioOutput()->setVolume(0.7f);
+	m_captureSound->audioOutput()->setVolume(0.7f);
+	m_victorySound->audioOutput()->setVolume(0.8f);
+#else
 	m_moveSound->setMedia(QUrl("qrc:/sound/Move.mp3"));
 	m_captureSound->setMedia(QUrl("qrc:/sound/Capture.mp3"));
 	m_victorySound->setMedia(QUrl("qrc:/sound/victory.mp3"));
 	m_moveSound->setVolume(70);
 	m_captureSound->setVolume(70);
 	m_victorySound->setVolume(80);
+#endif
 
 	// Keep game notifications out of the sidebar layout. This compact overlay
 	// behaves like a status bar and never changes the window's size hint.

--- a/gui/tile.h
+++ b/gui/tile.h
@@ -29,8 +29,8 @@ class Tile: public QLabel
 {
 public:
 	//Constructors
-	Tile(QWidget* pParent=0, Qt::WindowFlags f=0);
-	Tile(const QString& text, QWidget* pParent = 0, Qt::WindowFlags f = 0);
+	Tile(QWidget* pParent=0, Qt::WindowFlags f=Qt::WindowFlags());
+	Tile(const QString& text, QWidget* pParent = 0, Qt::WindowFlags f = Qt::WindowFlags());
 
 	//Methods
 protected:

--- a/gui/toaster/RetroChessToasterNotify.cpp
+++ b/gui/toaster/RetroChessToasterNotify.cpp
@@ -26,6 +26,9 @@
 #include "gui/toaster/ToasterItem.h"
 #include <retroshare/rspeers.h>
 #include <QMediaPlayer>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QAudioOutput>
+#endif
 #include <QUrl>
 
 namespace
@@ -38,7 +41,12 @@ RetroChessToasterNotify::RetroChessToasterNotify(
         RetroChessNotify *notify, QObject *parent)
     : ToasterNotify(parent), mNotify(notify), mInviteSound(new QMediaPlayer(this))
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	mInviteSound->setAudioOutput(new QAudioOutput(mInviteSound));
+	mInviteSound->setSource(QUrl("qrc:/sound/ping.mp3"));
+#else
 	mInviteSound->setMedia(QUrl("qrc:/sound/ping.mp3"));
+#endif
 	connect(notify, &RetroChessNotify::chessInvited,
 	        this, &RetroChessToasterNotify::chessInvited, Qt::QueuedConnection);
 	connect(notify, &RetroChessNotify::chessInvitedGxs,


### PR DESCRIPTION
Adds a CMake build for the plugin and fixes the Qt6 build.

- CMakeLists.txt resolves the RetroShare super-project root relative to the plugin dir, so it configures both standalone (cmake run in this dir) and via add_subdirectory. Requires the clone to live in <root>/plugins/RetroChess, same as the qmake setup.
- Qt6: QMediaPlayer setMedia/setVolume replaced with setSource + QAudioOutput (guarded, Qt5 unchanged), Qt::WindowFlags default args, Qt::DefaultLocaleShortDate -> QLocale.

Build-tested on Linux with Qt 5.15 and Qt 6, both link cleanly.

Standalone usage:

    cmake -S . -B build -DQT_VERSION_MAJOR=5
    cmake --build build

🤖 Generated with [Claude Code](https://claude.com/claude-code)