### PR TITLE
Bug fixes: memory leaks, thread safety, protocol validation

### DIFF
--- a/gui/NEMainpage.cpp
+++ b/gui/NEMainpage.cpp
@@ -502,6 +502,19 @@ void NEMainpage::NeMsgArrived(const RsPeerId &peer_id, QString str)
 
 void NEMainpage::create_chess_window(std::string peer_id, int player_id)
 {
+	if (RetroChessWindow *existing = activeGames.value(peer_id, nullptr)) {
+		if (existing->m_flag_finished == 0) {
+			// A game with this opponent is already running. Overwriting the
+			// map entry would orphan the old window (it stays open but stops
+			// receiving moves) — just bring it to the front instead.
+			existing->raise();
+			existing->activateWindow();
+			return;
+		}
+		// Finished game: close it silently before opening the new one.
+		existing->closeForRematch();
+	}
+
 	RetroChessWindow *rcw = new RetroChessWindow(peer_id, player_id);
 	connect(rcw, SIGNAL(rematchRequestedPeer(QString,int)),
 	        this, SLOT(requestRematchPeer(QString,int)));
@@ -529,8 +542,18 @@ void NEMainpage::requestRematchPeer(QString peerId, int localColor)
 
 void NEMainpage::create_chess_window_gxs(const RsGxsId &gxs_id, int player_id)
 {
+    if (RetroChessWindow *existing = activeGames.value(gxs_id.toStdString(), nullptr)) {
+        if (existing->m_flag_finished == 0) {
+            // Same as create_chess_window(): never orphan a running game.
+            existing->raise();
+            existing->activateWindow();
+            return;
+        }
+        existing->closeForRematch();
+    }
+
     // Open the window with the GXS constructor
-    RetroChessWindow *win = new RetroChessWindow(gxs_id, player_id); 
+    RetroChessWindow *win = new RetroChessWindow(gxs_id, player_id);
     connect(win, SIGNAL(rematchRequested(RsGxsId,int)),
             this, SLOT(requestRematchGxs(RsGxsId,int)));
     connect(win, SIGNAL(gameClosed(QString)), this, SLOT(removeActiveGame(QString)));

--- a/gui/NEMainpage.cpp
+++ b/gui/NEMainpage.cpp
@@ -496,6 +496,9 @@ void NEMainpage::NeMsgArrived(const RsPeerId &peer_id, QString str)
 		output+= QString::fromStdString(rsPeers->getPeerName(peer_id));
 		output+=": ";
 		output+=str;
+		// Any peer can feed this list; never let it grow without bound.
+		while (ui->netLogWidget->count() >= 200)
+			delete ui->netLogWidget->takeItem(0);
 		ui->netLogWidget->addItem(output);
 	}
 }

--- a/gui/NEMainpage.cpp
+++ b/gui/NEMainpage.cpp
@@ -427,10 +427,6 @@ void NEMainpage::NeMsgArrived(const RsPeerId &peer_id, QString str)
 			}
 		}
     }
-	else if (type == "chess_init")
-    {
-        create_chess_window(peer_id.toStdString(), 1);
-    }
 	else if (type == "chess_invite")
 	{
 		ChatDialog::chatFriend(ChatId(peer_id));

--- a/gui/NEMainpage.cpp
+++ b/gui/NEMainpage.cpp
@@ -27,6 +27,8 @@
 
 #include <qjsondocument.h>
 
+#include <QPointer>
+
 #include <iostream>
 #include <algorithm>
 #include <string>
@@ -367,13 +369,18 @@ void NEMainpage::chessRematchGxs(const RsGxsId &gxs_id, int remoteColor)
 		rsRetroChess->sendGameActionGxs(gxs_id, "rematch_decline");
 		return;
 	}
-	RetroChessWindow *window = activeGames.value(key);
+	QPointer<RetroChessWindow> window = activeGames.value(key);
 	const bool alreadyRequested = window->m_rematchRequested;
 	if (!alreadyRequested && QMessageBox::question(
 	        window, tr("Rematch"), tr("Your opponent requests a rematch. Accept?")) != QMessageBox::Yes) {
 		rsRetroChess->sendGameActionGxs(gxs_id, "rematch_decline");
 		return;
 	}
+	// The question box spins a nested event loop: other network slots run
+	// meanwhile and may have destroyed the window (e.g. a concurrent rematch
+	// or close). Never touch it again without checking.
+	if (!window)
+		return;
 	if (!alreadyRequested)
 		rsRetroChess->sendRematchGxs(gxs_id, window->m_localplayer_turn);
 	window->closeForRematch();
@@ -452,7 +459,7 @@ void NEMainpage::NeMsgArrived(const RsPeerId &peer_id, QString str)
 			rsRetroChess->qvm_msg_peer(peer_id, decline);
 			return;
 		}
-		RetroChessWindow *window = activeGames.value(key);
+		QPointer<RetroChessWindow> window = activeGames.value(key);
 		const bool alreadyRequested = window->m_rematchRequested;
 		if (!alreadyRequested && QMessageBox::question(
 		        window, tr("Rematch"), tr("Your opponent requests a rematch. Accept?")) != QMessageBox::Yes) {
@@ -462,6 +469,10 @@ void NEMainpage::NeMsgArrived(const RsPeerId &peer_id, QString str)
 			rsRetroChess->qvm_msg_peer(peer_id, decline);
 			return;
 		}
+		// Same nested-event-loop hazard as chessRematchGxs(): the window may
+		// have been destroyed while the question box was open.
+		if (!window)
+			return;
 		if (!alreadyRequested) {
 			QVariantMap accept;
 			accept.insert("type", "chess_rematch");

--- a/gui/NEMainpage.cpp
+++ b/gui/NEMainpage.cpp
@@ -313,7 +313,10 @@ void NEMainpage::chessMoveGxs(const RsGxsId &gxs_id, int col, int row, int count
 	std::string key = gxs_id.toStdString();
 	if (activeGames.find(key) != activeGames.end()) {
 		RetroChessWindow* rcw = activeGames.value(key);
-		if (rcw->m_flag_finished == 0)
+		// Remote clicks may only act while it is the remote player's turn.
+		// validate() itself only checks pieceColor == turn, so without this
+		// gate a hostile client could select and move OUR pieces.
+		if (rcw->m_flag_finished == 0 && rcw->turn != rcw->m_localplayer_turn)
 			rcw->validate_tile(row, col, count);
 	} else {
 		std::cerr << "RetroChess: Received GXS move but no active game for " << key << std::endl;
@@ -404,7 +407,9 @@ void NEMainpage::NeMsgArrived(const RsPeerId &peer_id, QString str)
 		int col = vmap.value("col").toInt();
 		int count = vmap.value("count").toInt();
 		RetroChessWindow* rcw = activeGames.value(peer_id.toStdString(), nullptr);
-		if (rcw && rcw->m_flag_finished == 0)
+		// Same turn gate as the GXS path: a remote click must not be able to
+		// drive our own pieces during our turn.
+		if (rcw && rcw->m_flag_finished == 0 && rcw->turn != rcw->m_localplayer_turn)
 			rcw->validate_tile(row,col,count);
 	}
     else if(type == "player_status_message")

--- a/gui/NEMainpage.cpp
+++ b/gui/NEMainpage.cpp
@@ -404,9 +404,11 @@ void NEMainpage::NeMsgArrived(const RsPeerId &peer_id, QString str)
 		return;
 	}
 	QVariantMap vmap = jdoc.toVariant().toMap();
+#ifdef DEBUG_RetroChess
 	std::cout << "GUI got Packet from: " << peer_id;
 	std::cout << " saying " << str.toStdString();
 	std::cout << std::endl;
+#endif
 	QString type = vmap.value("type").toString();
 	if (type == "chessclick")
 	{

--- a/gui/RetroChessNotify.cpp
+++ b/gui/RetroChessNotify.cpp
@@ -35,9 +35,11 @@ void RetroChessNotify::notifyReceivedPaint(const RsPeerId &peer_id, int x, int y
 
 void RetroChessNotify::notifyReceivedMsg(const RsPeerId& peer_id, QString str)
 {
+#ifdef DEBUG_RetroChess
 	std::cout << "pNotify Recvd Packet from: " << peer_id;
 	std::cout << " saying " << str.toStdString();
 	std::cout << std::endl;
+#endif
 	emit NeMsgArrived(peer_id, str) ;
 }
 

--- a/gui/chess.cpp
+++ b/gui/chess.cpp
@@ -41,6 +41,8 @@
 #include "RetroChessSettings.h"
 #include "ChessDebugWidget.h"
 
+#include <QPointer>
+
 #include "gui/common/AvatarDefs.h"
 #include "../services/p3RetroChess.h"
 
@@ -1546,7 +1548,10 @@ char RetroChessWindow::promotionChoiceForPawn(int color)
 		        ? choice : 'Q';
 	}
 
-	QDialog dialog(this);
+	// Deliberately parentless: exec() is application-modal anyway, and a
+	// stack-allocated child would be double-destroyed if this window got
+	// deleted while the nested event loop below is running.
+	QDialog dialog;
 	dialog.setWindowTitle(tr("Pawn promotion"));
 	QVBoxLayout layout(&dialog);
 	layout.addWidget(new QLabel(tr("Promote pawn to:"), &dialog));
@@ -1572,8 +1577,14 @@ char RetroChessWindow::promotionChoiceForPawn(int color)
 	layout.addWidget(&buttons);
 
 	char choice = 'Q';
+	QPointer<RetroChessWindow> self(this);
 	if (dialog.exec() == QDialog::Accepted)
 		choice = choices.currentData().toString().at(0).toLatin1();
+	// Network slots processed by the nested loop may have destroyed this
+	// window. The promotion choice now travels inside the move action, so
+	// nothing must be sent from here.
+	if (!self)
+		return 'Q';
 	return choice;
 }
 
@@ -2435,9 +2446,15 @@ void RetroChessWindow::applyGameAction(const QString &action, bool remote)
 		return;
 	}
 	if (action == "draw_offer" && remote) {
+		// The question box spins a nested event loop; other network slots may
+		// destroy this window meanwhile (rematch accept, close). Do not touch
+		// any member after exec without checking.
+		QPointer<RetroChessWindow> self(this);
 		const bool accepted = QMessageBox::question(
 		        this, tr("Draw offer"), tr("Your opponent offers a draw. Accept?"),
 		        QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes;
+		if (!self)
+			return;
 		sendGameAction(accepted ? "draw_accept" : "draw_decline");
 		if (accepted) applyGameAction("draw_accept", false);
 		return;

--- a/gui/tile.cpp
+++ b/gui/tile.cpp
@@ -24,6 +24,7 @@
 #include "../interface/rsRetroChess.h"
 
 #include <QIcon>
+#include <QPointer>
 
 /*extern int count,turn;
 extern QWidget *myWidget;
@@ -56,7 +57,12 @@ void Tile::mousePressEvent(QMouseEvent *event)
 			const bool destinationAttempt = fromTile >= 0
 			        && this != (chess_window_p)->click1
 			        && !(piece && pieceColor == (chess_window_p)->turn);
+			// validate() can run the modal promotion dialog, whose nested
+			// event loop may destroy the game window and this tile.
+			QPointer<Tile> selfGuard(this);
 			const bool moved = validate(++(chess_window_p)->count);
+			if (!selfGuard)
+				return;
 			if (moved && fromTile >= 0) {
 				const char promotion = movedPiece == 'P' && pieceName != 'P'
 				        ? pieceName : '-';
@@ -230,7 +236,15 @@ bool Tile::validate(int c)
                 tile_p->display((chess_window_p)->click1->pieceName);
 
                 (chess_window_p)->click1->tileDisplay();
-                tile_p->pawnLevelupCheck();
+                {
+                    // pawnLevelupCheck() may open the modal promotion dialog,
+                    // whose nested event loop can destroy the whole game
+                    // window (and this tile with it).
+                    QPointer<Tile> selfGuard(tile_p);
+                    tile_p->pawnLevelupCheck();
+                    if (!selfGuard)
+                        return false;
+                }
                 tile_p->tileDisplay();
 				const char promotedPiece = movedPiece == 'P' && tile_p->pieceName != 'P'
 				        ? tile_p->pieceName : 0;
@@ -300,17 +314,25 @@ void Tile::tileDisplay()
 
 void Tile::pawnLevelupCheck()
 {
-    if( this->pieceName == 'P')
-    {
-        // white
-        if( this->pieceColor && this->row == 0)
-			this->display(dynamic_cast<RetroChessWindow*>(m_chess_window_p)
-			        ->promotionChoiceForPawn(this->pieceColor));
-        // black
-        else if( this->pieceColor == 0 && this->row == 7)
-			this->display(dynamic_cast<RetroChessWindow*>(m_chess_window_p)
-			        ->promotionChoiceForPawn(this->pieceColor));
-    }
+    if( this->pieceName != 'P')
+        return;
+
+    // white promotes on row 0, black on row 7
+    if( !(this->pieceColor && this->row == 0)
+            && !(this->pieceColor == 0 && this->row == 7))
+        return;
+
+    RetroChessWindow *chess_window_p = dynamic_cast<RetroChessWindow*>(m_chess_window_p);
+    if (!chess_window_p)
+        return;
+
+    // promotionChoiceForPawn() runs a modal dialog: guard against this tile
+    // being destroyed by slots processed in its nested event loop.
+    QPointer<Tile> self(this);
+    const char choice = chess_window_p->promotionChoiceForPawn(this->pieceColor);
+    if (!self)
+        return;
+    this->display(choice);
 }
 
 

--- a/services/p3RetroChess.cc
+++ b/services/p3RetroChess.cc
@@ -291,8 +291,10 @@ bool	p3RetroChess::recvItem(RsItem *item)
 	switch(item->PacketSubType())
 	{
 	case RS_PKT_SUBTYPE_RetroChess_DATA:
+		// handleData() only forwards the message string to the notifier and
+		// does not take ownership, so the item must not be kept: keeping it
+		// leaked one item per received message.
 		handleData(dynamic_cast<RsRetroChessDataItem*>(item));
-		keep = true ;
 		break;
 	/*case RS_PKT_SUBTYPE_RetroChess_INVITE:
 		if (invites.find(item->PeerId()!=invites.end())){

--- a/services/p3RetroChess.cc
+++ b/services/p3RetroChess.cc
@@ -375,12 +375,11 @@ void p3RetroChess::chess_click_gxs(const RsGxsId &gxs_id, int col, int row, int 
 
     RsGxsTunnelId tunnel_id = mActiveTunnels[gxs_id];
 
-    // Create a data item for the move
-    RsRetroChessDataItem *item = new RsRetroChessDataItem();
-    item->m_msg = QString("%1,%2,%3").arg(col).arg(row).arg(count).toStdString();
-
-    // Send raw data through the secured tunnel
-    mGxsTunnels->sendData(tunnel_id, RETRO_CHESS_GXS_TUNNEL_SERVICE_ID, (const uint8_t*)item->m_msg.c_str(), item->m_msg.size());
+    // sendData() copies the buffer, so a plain string is all that is needed.
+    // The RsRetroChessDataItem previously allocated here was never freed,
+    // leaking one item per move sent.
+    const std::string msg = QString("%1,%2,%3").arg(col).arg(row).arg(count).toStdString();
+    mGxsTunnels->sendData(tunnel_id, RETRO_CHESS_GXS_TUNNEL_SERVICE_ID, (const uint8_t*)msg.c_str(), msg.size());
 }
 
 void p3RetroChess::requestGxsTunnel(const RsGxsId &gxsId)

--- a/services/p3RetroChess.cc
+++ b/services/p3RetroChess.cc
@@ -568,7 +568,11 @@ bool p3RetroChess::doSendInviteOverGxs(const RsGxsId &toId, const RsGxsId &ownId
         if (mGxsTunnels->sendData(
                     activeTunnel, RETRO_CHESS_GXS_TUNNEL_SERVICE_ID,
                     reinterpret_cast<const uint8_t*>(invite.data()), invite.size()))
+        {
+            RsStackMutex stack(mRetroChessMtx);
+            mInvitesToGxs.insert(toId);
             return true;
+        }
 
         // A game may have closed before the tunnel-status callback reaches us.
         // Never lose a new invitation by continuing to trust that stale entry.
@@ -587,6 +591,7 @@ bool p3RetroChess::doSendInviteOverGxs(const RsGxsId &toId, const RsGxsId &ownId
         // invitation instead of replacing the tunnel ID on every button click.
         if (mPendingTunnels.find(toId) != mPendingTunnels.end()) {
             mPendingGxsInvites[toId] = invite;
+            mInvitesToGxs.insert(toId);
             return true;
         }
     }
@@ -599,6 +604,7 @@ bool p3RetroChess::doSendInviteOverGxs(const RsGxsId &toId, const RsGxsId &ownId
         RsStackMutex stack(mRetroChessMtx);
         mPendingTunnels[toId] = tunnelId;
         mPendingGxsInvites[toId] = "{\"type\":\"chess_invite\"}";
+        mInvitesToGxs.insert(toId);
         std::cout << "Chess: Tunnel requested (id=" << tunnelId << "), invite queued for " << toId << std::endl;
         return true;
     } else {
@@ -749,6 +755,19 @@ void p3RetroChess::handleRawData(const RsGxsId& gxs_id,
         mNotify->notifyChessInviteGxs(sender_id);
 
     } else if (type == "chess_accept") {
+        // Only honour an accept for an invitation we actually sent, like
+        // hasInviteTo() on the direct-peer path. Otherwise any identity able
+        // to open a tunnel could spawn game windows at will.
+        bool invited;
+        {
+            RsStackMutex stack(mRetroChessMtx);
+            invited = mInvitesToGxs.erase(sender_id) > 0;
+        }
+        if (!invited) {
+            std::cerr << "Chess: Ignoring chess_accept from " << sender_id
+                      << " (no pending invitation)" << std::endl;
+            return;
+        }
         std::cout << "Chess: Received accept from GXS " << sender_id << std::endl;
         mNotify->notifyChessAcceptedGxs(sender_id);
 
@@ -845,6 +864,7 @@ void p3RetroChess::notifyTunnelStatus(const RsGxsTunnelId& tunnel_id, uint32_t t
             mTunnelToGxsIdMap.erase(tunnel_id);
             if (!gxs_id.isNull()) {
                 mInvitesFromGxs.erase(gxs_id);
+                mInvitesToGxs.erase(gxs_id);
                 mPendingGxsInvites.erase(gxs_id);
                 mPendingGxsCloses.erase(gxs_id);
             }

--- a/services/p3RetroChess.cc
+++ b/services/p3RetroChess.cc
@@ -193,8 +193,10 @@ void p3RetroChess::sendInvite(RsPeerId peerID)
 
 void p3RetroChess::raw_msg_peer(RsPeerId peerID, std::string msg)
 {
+#ifdef DEBUG_RetroChess
 	std::cout << "MSging: " << peerID.toStdString() << "\n";
 	std::cout << "MSging: " << msg << "\n";
+#endif
 	/* create the packet */
 	RsRetroChessDataItem *pingPkt = new RsRetroChessDataItem();
 	pingPkt->PeerId(peerID);
@@ -284,7 +286,9 @@ void p3RetroChess::handleData(RsRetroChessDataItem *item)
 
 bool	p3RetroChess::recvItem(RsItem *item)
 {
+#ifdef DEBUG_RetroChess
 	std::cout << "recvItem type: " << item->PacketSubType() << "\n";
+#endif
 	/* pass to specific handler */
 	bool keep = false ;
 
@@ -754,7 +758,9 @@ void p3RetroChess::handleRawData(const RsGxsId& gxs_id,
 
     // All messages are JSON
     std::string msg((const char*)data, data_size);
+#ifdef DEBUG_RetroChess
     std::cout << "Chess::handleRawData: received from " << sender_id << ": " << msg << std::endl;
+#endif
 
     QJsonDocument jsondoc = QJsonDocument::fromJson(QByteArray::fromStdString(msg));
     QVariantMap map = jsondoc.toVariant().toMap();

--- a/services/p3RetroChess.cc
+++ b/services/p3RetroChess.cc
@@ -536,9 +536,12 @@ bool p3RetroChess::sendInvite_chat(const ChatId &chatId)
         std::cout << "Chess: sendInvite_chat: distant chat not ready yet, queuing retry for "
                   << chatId.toStdString() << std::endl;
         RsStackMutex stack(mRetroChessMtx);
-        // Only add once; don't reset timestamp on duplicate clicks
+        // Only add once; don't reset timestamps on duplicate clicks
         if (mPendingDistantChatInvites.find(chatId.toDistantChatId()) == mPendingDistantChatInvites.end()) {
-            mPendingDistantChatInvites[chatId.toDistantChatId()] = time(NULL);
+            PendingDistantInvite pending;
+            pending.queuedTS = time(NULL);
+            pending.lastTryTS = pending.queuedTS;
+            mPendingDistantChatInvites[chatId.toDistantChatId()] = pending;
         }
         return true;
     }
@@ -615,7 +618,12 @@ bool p3RetroChess::doSendInviteOverGxs(const RsGxsId &toId, const RsGxsId &ownId
 
 void p3RetroChess::retryPendingDistantChatInvites()
 {
-    std::map<DistantChatPeerId, time_t> pending;
+    // Stop retrying an invite whose distant chat never comes up. Without a
+    // deadline a single click on the chess button of an offline identity
+    // meant a retry every 2 seconds for the whole session.
+    static const time_t GIVE_UP_AFTER_SECS = 600;
+
+    std::map<DistantChatPeerId, PendingDistantInvite> pending;
     {
         RsStackMutex stack(mRetroChessMtx);
         pending = mPendingDistantChatInvites;
@@ -625,8 +633,16 @@ void p3RetroChess::retryPendingDistantChatInvites()
 
     time_t now = time(NULL);
     for (auto it = pending.begin(); it != pending.end(); ++it) {
+        if (now - it->second.queuedTS > GIVE_UP_AFTER_SECS) {
+            std::cerr << "Chess: giving up on distant chat invite for "
+                      << it->first << " (tunnel never came up)" << std::endl;
+            RsStackMutex stack(mRetroChessMtx);
+            mPendingDistantChatInvites.erase(it->first);
+            continue;
+        }
+
         // Throttle: only retry every 2 seconds
-        if (now - it->second < 2) continue;
+        if (now - it->second.lastTryTS < 2) continue;
 
         DistantChatPeerInfo info;
         if (rsChats->getDistantChatStatus(it->first, info)
@@ -645,7 +661,9 @@ void p3RetroChess::retryPendingDistantChatInvites()
         } else {
             // Still not ready — update timestamp so we wait another 2 seconds
             RsStackMutex stack(mRetroChessMtx);
-            mPendingDistantChatInvites[it->first] = now;
+            auto mit = mPendingDistantChatInvites.find(it->first);
+            if (mit != mPendingDistantChatInvites.end())
+                mit->second.lastTryTS = now;
         }
     }
 }

--- a/services/p3RetroChess.cc
+++ b/services/p3RetroChess.cc
@@ -885,6 +885,9 @@ void p3RetroChess::notifyTunnelStatus(const RsGxsTunnelId& tunnel_id, uint32_t t
                 mInvitesToGxs.erase(gxs_id);
                 mPendingGxsInvites.erase(gxs_id);
                 mPendingGxsCloses.erase(gxs_id);
+                // Re-populated on the next invite; without this the map grew
+                // for the whole session.
+                mOwnGxsIdByPeer.erase(gxs_id);
             }
         }
         if (!gxs_id.isNull()) {

--- a/services/p3RetroChess.cc
+++ b/services/p3RetroChess.cc
@@ -366,14 +366,20 @@ RsSerialiser *p3RetroChess::setupSerialiser()
 
 void p3RetroChess::chess_click_gxs(const RsGxsId &gxs_id, int col, int row, int count)
 {
-    RsStackMutex stack(mRetroChessMtx); /****** LOCKED MUTEX *******/
-    if (mActiveTunnels.find(gxs_id) == mActiveTunnels.end()) {
-        // Tunnel not ready, try to re-open
+    RsGxsTunnelId tunnel_id;
+    {
+        RsStackMutex stack(mRetroChessMtx); /****** LOCKED MUTEX *******/
+        auto it = mActiveTunnels.find(gxs_id);
+        if (it != mActiveTunnels.end())
+            tunnel_id = it->second;
+    }
+
+    if (tunnel_id.isNull()) {
+        // Tunnel not ready, try to re-open. Called unlocked: sendGxsInvite
+        // takes the mutex itself and RsMutex is not recursive.
         sendGxsInvite(gxs_id);
         return;
     }
-
-    RsGxsTunnelId tunnel_id = mActiveTunnels[gxs_id];
 
     // sendData() copies the buffer, so a plain string is all that is needed.
     // The RsRetroChessDataItem previously allocated here was never freed,
@@ -385,16 +391,23 @@ void p3RetroChess::chess_click_gxs(const RsGxsId &gxs_id, int col, int row, int 
 void p3RetroChess::requestGxsTunnel(const RsGxsId &gxsId)
 {
     // Check if we already have a tunnel
-    if (mActiveTunnels.count(gxsId)) {
+    bool active;
+    {
+        RsStackMutex stack(mRetroChessMtx);
+        active = mActiveTunnels.count(gxsId) > 0;
+    }
+    if (active) {
         mNotify->notifyGxsTunnelReady(gxsId);
         return;
     }
     // Otherwise, start the async tunnel request
-    this->sendGxsInvite(gxsId); 
+    this->sendGxsInvite(gxsId);
 }
 
 void p3RetroChess::sendGxsInvite(const RsGxsId &to_gxs_id)
 {
+    if (!mGxsTunnels) return;
+
     RsGxsId from_gxs_id;
     std::list<RsGxsId> ownIds;
     rsIdentity->getOwnIds(ownIds);
@@ -406,9 +419,10 @@ void p3RetroChess::sendGxsInvite(const RsGxsId &to_gxs_id)
 
     // Open a tunnel using mGxsTunnel (Async Request)
     if (mGxsTunnels->requestSecuredTunnel(
-            to_gxs_id, from_gxs_id, tunnel_id, 
-            RETRO_CHESS_GXS_TUNNEL_SERVICE_ID, error_code)) 
+            to_gxs_id, from_gxs_id, tunnel_id,
+            RETRO_CHESS_GXS_TUNNEL_SERVICE_ID, error_code))
     {
+        RsStackMutex stack(mRetroChessMtx);
         mPendingTunnels[to_gxs_id] = tunnel_id;
         std::cout << "Chess Tunnel requested. Pending ID: " << tunnel_id << std::endl;
     }
@@ -418,20 +432,28 @@ void p3RetroChess::acceptedInviteGxs(const RsGxsId &gxsId)
 {
     std::cout << "Chess: acceptedInviteGxs from " << gxsId << std::endl;
 
-    RsStackMutex stack(mRetroChessMtx);
-    mInvitesFromGxs.erase(gxsId);
-    auto it = mActiveTunnels.find(gxsId);
-    if (it != mActiveTunnels.end()) {
+    RsGxsTunnelId activeTunnel;
+    {
+        RsStackMutex stack(mRetroChessMtx);
+        mInvitesFromGxs.erase(gxsId);
+        auto it = mActiveTunnels.find(gxsId);
+        if (it != mActiveTunnels.end())
+            activeTunnel = it->second;
+        else
+            // Client side: we initiated the invite but the tunnel isn't in
+            // mActiveTunnels yet. Queue accept for when it becomes CAN_TALK.
+            mPendingGxsInvites[gxsId] = "{\"type\":\"chess_accept\"}";
+    }
+
+    if (!activeTunnel.isNull()) {
         // Tunnel already active (server side — invite arrived over it).
-        // Send chess_accept immediately.
-        std::string accept = "{\"type\":\"chess_accept\"}";
-        std::cout << "Chess: Sending chess_accept over tunnel " << it->second << std::endl;
-        mGxsTunnels->sendData(it->second, RETRO_CHESS_GXS_TUNNEL_SERVICE_ID,
+        // Send chess_accept immediately, outside the mutex.
+        if (!mGxsTunnels) return;
+        const std::string accept = "{\"type\":\"chess_accept\"}";
+        std::cout << "Chess: Sending chess_accept over tunnel " << activeTunnel << std::endl;
+        mGxsTunnels->sendData(activeTunnel, RETRO_CHESS_GXS_TUNNEL_SERVICE_ID,
                               (const uint8_t*)accept.c_str(), accept.size());
     } else {
-        // Client side: we initiated the invite but tunnel isn't in mActiveTunnels yet.
-        // Queue accept for when tunnel becomes CAN_TALK.
-        mPendingGxsInvites[gxsId] = "{\"type\":\"chess_accept\"}";
         requestGxsTunnel(gxsId);
     }
 }
@@ -625,40 +647,62 @@ void p3RetroChess::retryPendingDistantChatInvites()
 
 void p3RetroChess::handleGxsTick()
 {
-    auto it = mPendingTunnels.begin();
-    while (it != mPendingTunnels.end()) {
+    // Runs on the service tick thread while the GUI thread mutates the same
+    // maps under mRetroChessMtx, so every map access here must be locked too.
+    // Tunnel-service calls and notifications happen outside the mutex.
+    if (!mGxsTunnels) return;
+
+    std::map<RsGxsId, RsGxsTunnelId> pending;
+    {
+        RsStackMutex stack(mRetroChessMtx); /****** LOCKED MUTEX *******/
+        pending = mPendingTunnels;
+    }
+    if (pending.empty()) return;
+
+    std::list<std::pair<RsGxsTunnelId, std::string> > flushes;
+    std::list<RsGxsId> ready;
+
+    for (auto it = pending.begin(); it != pending.end(); ++it) {
         RsGxsTunnelService::GxsTunnelInfo tinfo;
-        if (mGxsTunnels->getTunnelInfo(it->second, tinfo)) {
-            // Check if the tunnel is "Connected" (CAN_TALK)
-            if (tinfo.tunnel_status == RsGxsTunnelService::RS_GXS_TUNNEL_STATUS_CAN_TALK) {
-                RsGxsId gxsId = it->first;
-                RsGxsTunnelId tunnelId = it->second;
-                mActiveTunnels[gxsId] = tunnelId;
-                it = mPendingTunnels.erase(it);
+        if (!mGxsTunnels->getTunnelInfo(it->second, tinfo))
+            continue;
 
-                // Flush any queued invite for this peer
-                auto inviteIt = mPendingGxsInvites.find(gxsId);
-                if (inviteIt != mPendingGxsInvites.end()) {
-                    std::string invite = inviteIt->second;
-                    mPendingGxsInvites.erase(inviteIt);
-                    std::cout << "Chess: Tunnel ready, flushing queued invite to " << gxsId << std::endl;
-                    mGxsTunnels->sendData(tunnelId, RETRO_CHESS_GXS_TUNNEL_SERVICE_ID,
-                                         (const uint8_t*)invite.c_str(), invite.size());
-                }
+        // Check if the tunnel is "Connected" (CAN_TALK)
+        if (tinfo.tunnel_status == RsGxsTunnelService::RS_GXS_TUNNEL_STATUS_CAN_TALK) {
+            RsStackMutex stack(mRetroChessMtx); /****** LOCKED MUTEX *******/
+            auto pit = mPendingTunnels.find(it->first);
+            if (pit == mPendingTunnels.end() || pit->second != it->second)
+                continue; // changed concurrently, handle on next tick
+            mActiveTunnels[it->first] = it->second;
+            mPendingTunnels.erase(pit);
 
-                mNotify->notifyGxsTunnelReady(gxsId);
-                continue;
+            // Flush any queued invite for this peer
+            auto inviteIt = mPendingGxsInvites.find(it->first);
+            if (inviteIt != mPendingGxsInvites.end()) {
+                flushes.push_back(std::make_pair(it->second, inviteIt->second));
+                mPendingGxsInvites.erase(inviteIt);
             }
-            // Check for "Closed/Failed" status
-            else if (tinfo.tunnel_status == RsGxsTunnelService::RS_GXS_TUNNEL_STATUS_REMOTELY_CLOSED ||
-                     tinfo.tunnel_status == RsGxsTunnelService::RS_GXS_TUNNEL_STATUS_TUNNEL_DN) {
+            ready.push_back(it->first);
+        }
+        // Check for "Closed/Failed" status
+        else if (tinfo.tunnel_status == RsGxsTunnelService::RS_GXS_TUNNEL_STATUS_REMOTELY_CLOSED ||
+                 tinfo.tunnel_status == RsGxsTunnelService::RS_GXS_TUNNEL_STATUS_TUNNEL_DN) {
+            RsStackMutex stack(mRetroChessMtx); /****** LOCKED MUTEX *******/
+            auto pit = mPendingTunnels.find(it->first);
+            if (pit != mPendingTunnels.end() && pit->second == it->second) {
                 mPendingGxsInvites.erase(it->first); // discard queued invite
-                it = mPendingTunnels.erase(it);
-                continue;
+                mPendingTunnels.erase(pit);
             }
         }
-        ++it;
     }
+
+    for (auto it = flushes.begin(); it != flushes.end(); ++it) {
+        std::cout << "Chess: Tunnel ready, flushing queued invite" << std::endl;
+        mGxsTunnels->sendData(it->first, RETRO_CHESS_GXS_TUNNEL_SERVICE_ID,
+                              (const uint8_t*)it->second.c_str(), it->second.size());
+    }
+    for (auto it = ready.begin(); it != ready.end(); ++it)
+        mNotify->notifyGxsTunnelReady(*it);
 }
 
 

--- a/services/p3RetroChess.h
+++ b/services/p3RetroChess.h
@@ -148,6 +148,9 @@ private:
 	std::set<RsPeerId> invitesTo;
 	std::set<RsPeerId> invitesFrom;
 	std::set<RsGxsId> mInvitesFromGxs;
+	// GXS identities we sent (or queued) a chess_invite to. A chess_accept
+	// from anyone else must be ignored, like hasInviteTo() on the peer path.
+	std::set<RsGxsId> mInvitesToGxs;
 
 	void handleData(RsRetroChessDataItem*) ;
 

--- a/services/p3RetroChess.h
+++ b/services/p3RetroChess.h
@@ -167,8 +167,10 @@ private:
 	// Leave messages get a short delivery window before their tunnel is closed.
 	std::map<RsGxsId, time_t> mPendingGxsCloses;
 	// DistantChatIds for which sendInvite_chat() was called but getDistantChatStatus()
-	// failed (tunnel not established yet). Retried every tick() until it succeeds.
-	std::map<DistantChatPeerId, time_t> mPendingDistantChatInvites;
+	// failed (tunnel not established yet). Retried every tick() until it succeeds
+	// or the give-up deadline passes.
+	struct PendingDistantInvite { time_t queuedTS; time_t lastTryTS; };
+	std::map<DistantChatPeerId, PendingDistantInvite> mPendingDistantChatInvites;
 
 	RsGxsTunnelService *mGxsTunnels;
 	RsMutex mRetroChessMtx;

--- a/services/rsRetroChessItems.cc
+++ b/services/rsRetroChessItems.cc
@@ -88,7 +88,9 @@ bool RsRetroChessDataItem::serialise(void *data, uint32_t& pktsize)
 
 
 	ok &= setRawString(data, tlvsize, &offset, m_msg );
+#ifdef RSSERIAL_DEBUG
 	std::cout << "string sizes: " << getRawStringSize(m_msg) << " OR " << m_msg.size() << "\n";
+#endif
 
 	if (offset != tlvsize)
 	{

--- a/services/rsRetroChessItems.h
+++ b/services/rsRetroChessItems.h
@@ -84,7 +84,9 @@ public:
 class RsRetroChessDataItem: public RsRetroChessItem
 {
 public:
-	RsRetroChessDataItem() :RsRetroChessItem(RS_PKT_SUBTYPE_RetroChess_DATA) {}
+	// flags and data_size must not stay uninitialized: serialise() writes
+	// both to the wire, which leaked 4 bytes of heap garbage per packet.
+	RsRetroChessDataItem() :RsRetroChessItem(RS_PKT_SUBTYPE_RetroChess_DATA), flags(0), data_size(0) {}
 	RsRetroChessDataItem(void *data,uint32_t size) ; // de-serialization
 
 	virtual bool serialise(void *data,uint32_t& size) ;


### PR DESCRIPTION
One commit per fix:

- Fix two memory leaks: every received direct-peer item, and one data item per GXS move sent
- Initialize `flags`/`data_size` (4 bytes of uninitialized heap were serialized with every packet)
- Protect the tunnel maps with the service mutex (`handleGxsTick` raced against the GUI thread)
- Ignore a GXS `chess_accept` we never invited, and only apply remote clicks on the remote player's turn
- Drop the unauthenticated `chess_init` message (nothing sends it)
- Guard game windows with `QPointer` across nested modal dialog loops (use-after-free on rematch/draw/promotion)
- Give up on unresolved distant-chat invites after 10 min (was retrying every 2 s forever)
- Don't orphan an existing game window on duplicate start
- Bound `mOwnGxsIdByPeer` and the net-log list; move per-message stdout traces behind `DEBUG_RetroChess`

Builds with Qt5 and Qt6, merges cleanly with #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)