### PR TITLE
Implemented functional persistent Game History.

### DIFF
--- a/RetroChess.pro
+++ b/RetroChess.pro
@@ -50,6 +50,8 @@ SOURCES = RetroChessPlugin.cpp               \
           gui/RetroChessNotify.cpp \
           gui/chess.cpp \
           gui/ChessDebugWidget.cpp \
+          gui/ChessGameHistory.cpp \
+          gui/ChessGameReviewDialog.cpp \
           gui/tile.cpp \
           gui/RetroChessChatWidgetHolder.cpp \
           gui/RetroChessSettings.cpp \
@@ -59,6 +61,8 @@ SOURCES = RetroChessPlugin.cpp               \
 
 HEADERS = RetroChessPlugin.h                 \
           gui/ChessDebugWidget.h \
+          gui/ChessGameHistory.h \
+          gui/ChessGameReviewDialog.h \
           services/p3RetroChess.h            \
           services/rsRetroChessItems.h       \
           interface/rsRetroChess.h \

--- a/gui/ChessGameHistory.cpp
+++ b/gui/ChessGameHistory.cpp
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * gui/ChessGameHistory.cpp                                                   *
+ *                                                                             *
+ * Copyright (C) 2026 RetroShare Team <retroshare.project@gmail.com>           *
+ *                                                                             *
+ * This program is free software: you can redistribute it and/or modify        *
+ * it under the terms of the GNU Affero General Public License as              *
+ * published by the Free Software Foundation, either version 3 of the          *
+ * License, or (at your option) any later version.                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful,             *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                *
+ * GNU Affero General Public License for more details.                         *
+ *                                                                             *
+ * You should have received a copy of the GNU Affero General Public License    *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+
+#include "ChessGameHistory.h"
+
+#include "gui/settings/rsharesettings.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QUuid>
+
+namespace
+{
+const char *HISTORY_KEY = "GameHistory";
+const int MAX_SAVED_GAMES = 500;
+
+QJsonArray stringsToJson(const QStringList &values)
+{
+	QJsonArray result;
+	for (const QString &value : values) result.append(value);
+	return result;
+}
+
+QStringList stringsFromJson(const QJsonArray &values)
+{
+	QStringList result;
+	for (const QJsonValue &value : values) result.append(value.toString());
+	return result;
+}
+
+QJsonObject toJson(const ChessGameRecord &game)
+{
+	QJsonObject object;
+	object["id"] = game.id;
+	object["started"] = game.startedAt.toString(Qt::ISODateWithMs);
+	object["ended"] = game.endedAt.toString(Qt::ISODateWithMs);
+	object["white"] = game.whitePlayer;
+	object["black"] = game.blackPlayer;
+	object["result"] = game.result;
+	object["reason"] = game.reason;
+	object["moves"] = stringsToJson(game.moves);
+	object["positions"] = stringsToJson(game.positions);
+	return object;
+}
+
+ChessGameRecord fromJson(const QJsonObject &object)
+{
+	ChessGameRecord game;
+	game.id = object["id"].toString();
+	game.startedAt = QDateTime::fromString(object["started"].toString(), Qt::ISODateWithMs);
+	game.endedAt = QDateTime::fromString(object["ended"].toString(), Qt::ISODateWithMs);
+	game.whitePlayer = object["white"].toString();
+	game.blackPlayer = object["black"].toString();
+	game.result = object["result"].toString();
+	game.reason = object["reason"].toString();
+	game.moves = stringsFromJson(object["moves"].toArray());
+	game.positions = stringsFromJson(object["positions"].toArray());
+	return game;
+}
+
+bool saveGames(const QVector<ChessGameRecord> &games)
+{
+	QJsonArray array;
+	for (const ChessGameRecord &game : games) array.append(toJson(game));
+	Settings->setValueToGroup(
+	        "RetroChess", HISTORY_KEY,
+	        QJsonDocument(array).toJson(QJsonDocument::Compact));
+	Settings->sync();
+	return true;
+}
+}
+
+QVector<ChessGameRecord> ChessGameHistory::games()
+{
+	const QByteArray encoded = Settings->valueFromGroup(
+	        "RetroChess", HISTORY_KEY, QByteArray()).toByteArray();
+	const QJsonDocument document = QJsonDocument::fromJson(encoded);
+	QVector<ChessGameRecord> result;
+	if (!document.isArray()) return result;
+	for (const QJsonValue &value : document.array()) {
+		if (!value.isObject()) continue;
+		ChessGameRecord game = fromJson(value.toObject());
+		if (!game.id.isEmpty() && !game.positions.isEmpty()) result.append(game);
+	}
+	return result;
+}
+
+bool ChessGameHistory::addGame(const ChessGameRecord &value)
+{
+	ChessGameRecord game = value;
+	if (game.id.isEmpty())
+		game.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+	QVector<ChessGameRecord> all = games();
+	all.prepend(game);
+	while (all.size() > MAX_SAVED_GAMES) all.removeLast();
+	return saveGames(all);
+}
+
+bool ChessGameHistory::removeGame(const QString &id)
+{
+	QVector<ChessGameRecord> all = games();
+	for (int index = 0; index < all.size(); ++index)
+		if (all[index].id == id) {
+			all.remove(index);
+			return saveGames(all);
+		}
+	return false;
+}
+
+QString ChessGameHistory::toPgn(const ChessGameRecord &game)
+{
+	QString pgn = QString("[Event \"RetroChess game\"]\n"
+	                      "[Date \"%1\"]\n[White \"%2\"]\n"
+	                      "[Black \"%3\"]\n[Result \"%4\"]\n\n")
+	        .arg(game.startedAt.date().toString("yyyy.MM.dd"),
+	             game.whitePlayer, game.blackPlayer, game.result);
+	for (int index = 0; index < game.moves.size(); ++index) {
+		if (!(index % 2)) pgn += QString::number(index / 2 + 1) + ". ";
+		pgn += game.moves[index] + ' ';
+	}
+	return pgn + game.result + '\n';
+}

--- a/gui/ChessGameHistory.cpp
+++ b/gui/ChessGameHistory.cpp
@@ -54,6 +54,10 @@ QJsonObject toJson(const ChessGameRecord &game)
 	object["ended"] = game.endedAt.toString(Qt::ISODateWithMs);
 	object["white"] = game.whitePlayer;
 	object["black"] = game.blackPlayer;
+	object["whiteGxsId"] = game.whiteGxsId;
+	object["blackGxsId"] = game.blackGxsId;
+	object["whitePeerId"] = game.whitePeerId;
+	object["blackPeerId"] = game.blackPeerId;
 	object["result"] = game.result;
 	object["reason"] = game.reason;
 	object["moves"] = stringsToJson(game.moves);
@@ -69,6 +73,10 @@ ChessGameRecord fromJson(const QJsonObject &object)
 	game.endedAt = QDateTime::fromString(object["ended"].toString(), Qt::ISODateWithMs);
 	game.whitePlayer = object["white"].toString();
 	game.blackPlayer = object["black"].toString();
+	game.whiteGxsId = object["whiteGxsId"].toString();
+	game.blackGxsId = object["blackGxsId"].toString();
+	game.whitePeerId = object["whitePeerId"].toString();
+	game.blackPeerId = object["blackPeerId"].toString();
 	game.result = object["result"].toString();
 	game.reason = object["reason"].toString();
 	game.moves = stringsFromJson(object["moves"].toArray());

--- a/gui/ChessGameHistory.h
+++ b/gui/ChessGameHistory.h
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * gui/ChessGameHistory.h                                                     *
+ *                                                                             *
+ * Copyright (C) 2026 RetroShare Team <retroshare.project@gmail.com>           *
+ *                                                                             *
+ * This program is free software: you can redistribute it and/or modify        *
+ * it under the terms of the GNU Affero General Public License as              *
+ * published by the Free Software Foundation, either version 3 of the          *
+ * License, or (at your option) any later version.                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful,             *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                *
+ * GNU Affero General Public License for more details.                         *
+ *                                                                             *
+ * You should have received a copy of the GNU Affero General Public License    *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+
+#ifndef CHESSGAMEHISTORY_H
+#define CHESSGAMEHISTORY_H
+
+#include <QDateTime>
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+struct ChessGameRecord
+{
+	QString id;
+	QDateTime startedAt;
+	QDateTime endedAt;
+	QString whitePlayer;
+	QString blackPlayer;
+	QString result;
+	QString reason;
+	QStringList moves;
+	QStringList positions;
+};
+
+class ChessGameHistory
+{
+public:
+	static QVector<ChessGameRecord> games();
+	static bool addGame(const ChessGameRecord &game);
+	static bool removeGame(const QString &id);
+	static QString toPgn(const ChessGameRecord &game);
+};
+
+#endif // CHESSGAMEHISTORY_H

--- a/gui/ChessGameHistory.h
+++ b/gui/ChessGameHistory.h
@@ -33,6 +33,10 @@ struct ChessGameRecord
 	QDateTime endedAt;
 	QString whitePlayer;
 	QString blackPlayer;
+	QString whiteGxsId;
+	QString blackGxsId;
+	QString whitePeerId;
+	QString blackPeerId;
 	QString result;
 	QString reason;
 	QStringList moves;

--- a/gui/ChessGameReviewDialog.cpp
+++ b/gui/ChessGameReviewDialog.cpp
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * gui/ChessGameReviewDialog.cpp                                              *
+ *                                                                             *
+ * Copyright (C) 2026 RetroShare Team <retroshare.project@gmail.com>           *
+ *                                                                             *
+ * This program is free software: you can redistribute it and/or modify        *
+ * it under the terms of the GNU Affero General Public License as              *
+ * published by the Free Software Foundation, either version 3 of the          *
+ * License, or (at your option) any later version.                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful,             *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                *
+ * GNU Affero General Public License for more details.                         *
+ *                                                                             *
+ * You should have received a copy of the GNU Affero General Public License    *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+
+#include "ChessGameReviewDialog.h"
+
+#include "RetroChessSettings.h"
+
+#include <QDialogButtonBox>
+#include <QGridLayout>
+#include <QHeaderView>
+#include <QIcon>
+#include <QLabel>
+#include <QPushButton>
+#include <QTableWidget>
+#include <QVBoxLayout>
+
+ChessGameReviewDialog::ChessGameReviewDialog(
+        const ChessGameRecord &game, QWidget *parent)
+    : QDialog(parent), m_game(game), m_moves(nullptr), m_first(nullptr),
+      m_previous(nullptr), m_next(nullptr), m_last(nullptr),
+      m_positionLabel(nullptr), m_ply(0)
+{
+	setWindowTitle(tr("Review: %1 vs %2").arg(game.whitePlayer, game.blackPlayer));
+	setMinimumSize(760, 540);
+	QHBoxLayout *root = new QHBoxLayout(this);
+
+	QWidget *board = new QWidget(this);
+	QGridLayout *boardLayout = new QGridLayout(board);
+	boardLayout->setContentsMargins(0, 0, 0, 0);
+	boardLayout->setSpacing(0);
+	for (int index = 0; index < 64; ++index) {
+		QLabel *square = new QLabel(board);
+		square->setFixedSize(58, 58);
+		square->setAlignment(Qt::AlignCenter);
+		m_squares[index] = square;
+		boardLayout->addWidget(square, index / 8, index % 8);
+	}
+	root->addWidget(board, 0, Qt::AlignCenter);
+
+	QVBoxLayout *side = new QVBoxLayout;
+	QLabel *players = new QLabel(
+	        tr("White: %1\nBlack: %2\nResult: %3\n%4")
+	                .arg(game.whitePlayer, game.blackPlayer, game.result, game.reason), this);
+	players->setWordWrap(true);
+	side->addWidget(players);
+	m_moves = new QTableWidget((game.moves.size() + 1) / 2, 3, this);
+	m_moves->setHorizontalHeaderLabels({tr("#"), tr("White"), tr("Black")});
+	m_moves->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+	m_moves->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+	m_moves->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
+	m_moves->verticalHeader()->hide();
+	m_moves->setEditTriggers(QAbstractItemView::NoEditTriggers);
+	for (int index = 0; index < game.moves.size(); ++index) {
+		const int row = index / 2;
+		if (!m_moves->item(row, 0))
+			m_moves->setItem(row, 0, new QTableWidgetItem(QString::number(row + 1)));
+		m_moves->setItem(row, index % 2 + 1, new QTableWidgetItem(game.moves[index]));
+	}
+	side->addWidget(m_moves, 1);
+
+	QHBoxLayout *navigation = new QHBoxLayout;
+	m_first = new QPushButton(QIcon(":/images/skip-prev-solid.png"), QString(), this);
+	m_previous = new QPushButton(QIcon(":/images/nav-arrow-left-solid.png"), QString(), this);
+	m_next = new QPushButton(QIcon(":/images/nav-arrow-right-solid.png"), QString(), this);
+	m_last = new QPushButton(QIcon(":/images/skip-next-solid.png"), QString(), this);
+	for (QPushButton *button : {m_first, m_previous, m_next, m_last}) {
+		button->setFixedSize(36, 28);
+		navigation->addWidget(button);
+	}
+	side->addLayout(navigation);
+	m_positionLabel = new QLabel(this);
+	side->addWidget(m_positionLabel);
+	QDialogButtonBox *close = new QDialogButtonBox(QDialogButtonBox::Close, this);
+	connect(close, &QDialogButtonBox::rejected, this, &QDialog::reject);
+	side->addWidget(close);
+	root->addLayout(side, 1);
+
+	connect(m_first, &QPushButton::clicked, this, [this]() { showPly(0); });
+	connect(m_previous, &QPushButton::clicked, this, [this]() { showPly(m_ply - 1); });
+	connect(m_next, &QPushButton::clicked, this, [this]() { showPly(m_ply + 1); });
+	connect(m_last, &QPushButton::clicked, this, [this]() { showPly(m_game.positions.size() - 1); });
+	connect(m_moves, &QTableWidget::cellClicked, this, [this](int row, int column) {
+		if (column > 0) showPly(qMin(row * 2 + column, m_game.positions.size() - 1));
+	});
+	showPly(0);
+}
+
+void ChessGameReviewDialog::showPly(int ply)
+{
+	if (m_game.positions.isEmpty()) return;
+	m_ply = qBound(0, ply, m_game.positions.size() - 1);
+	const QString position = m_game.positions[m_ply];
+	const RetroChessBoardTheme theme = RetroChessSettings::boardTheme();
+	for (int index = 0; index < 64; ++index) {
+		QLabel *square = m_squares[index];
+		const QColor color = ((index / 8 + index % 8) % 2) ? theme.dark : theme.light;
+		square->setStyleSheet(QString("QLabel { background: %1; }").arg(color.name()));
+		square->clear();
+		if (index >= position.size() || position[index] == '.') continue;
+		const QChar encoded = position[index];
+		const QString colorPrefix = encoded.isUpper() ? "w" : "b";
+		QChar piece = encoded.toUpper();
+		if (piece == 'H') piece = 'N';
+		const QIcon icon(QString(":/piece/%1%2.svg").arg(colorPrefix).arg(piece));
+		square->setPixmap(icon.pixmap(50, 50));
+	}
+	if (m_ply == 0) m_moves->clearSelection();
+	else if (QTableWidgetItem *item = m_moves->item((m_ply - 1) / 2, (m_ply - 1) % 2 + 1)) {
+		m_moves->setCurrentItem(item);
+		m_moves->scrollToItem(item);
+	}
+	m_positionLabel->setText(tr("Position %1 of %2").arg(m_ply).arg(m_game.positions.size() - 1));
+	updateControls();
+}
+
+void ChessGameReviewDialog::updateControls()
+{
+	m_first->setEnabled(m_ply > 0);
+	m_previous->setEnabled(m_ply > 0);
+	m_next->setEnabled(m_ply + 1 < m_game.positions.size());
+	m_last->setEnabled(m_ply + 1 < m_game.positions.size());
+}

--- a/gui/ChessGameReviewDialog.h
+++ b/gui/ChessGameReviewDialog.h
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * gui/ChessGameReviewDialog.h                                                *
+ *                                                                             *
+ * Copyright (C) 2026 RetroShare Team <retroshare.project@gmail.com>           *
+ *                                                                             *
+ * This program is free software: you can redistribute it and/or modify        *
+ * it under the terms of the GNU Affero General Public License as              *
+ * published by the Free Software Foundation, either version 3 of the          *
+ * License, or (at your option) any later version.                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful,             *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                *
+ * GNU Affero General Public License for more details.                         *
+ *                                                                             *
+ * You should have received a copy of the GNU Affero General Public License    *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+
+#ifndef CHESSGAMEREVIEWDIALOG_H
+#define CHESSGAMEREVIEWDIALOG_H
+
+#include "ChessGameHistory.h"
+
+#include <QDialog>
+
+class QLabel;
+class QPushButton;
+class QTableWidget;
+
+class ChessGameReviewDialog : public QDialog
+{
+	Q_OBJECT
+
+public:
+	explicit ChessGameReviewDialog(const ChessGameRecord &game, QWidget *parent = nullptr);
+
+private:
+	void showPly(int ply);
+	void updateControls();
+
+	ChessGameRecord m_game;
+	QLabel *m_squares[64];
+	QTableWidget *m_moves;
+	QPushButton *m_first;
+	QPushButton *m_previous;
+	QPushButton *m_next;
+	QPushButton *m_last;
+	QLabel *m_positionLabel;
+	int m_ply;
+};
+
+#endif // CHESSGAMEREVIEWDIALOG_H

--- a/gui/NEMainpage.cpp
+++ b/gui/NEMainpage.cpp
@@ -32,7 +32,6 @@
 #include <iostream>
 #include <algorithm>
 #include <string>
-#include <QTime>
 #include <QMenu>
 #include <QMessageBox>
 #include <QToolButton>
@@ -44,8 +43,12 @@
 #include <QHBoxLayout>
 #include <QPushButton>
 #include <QTreeWidgetItem>
+#include <QFileDialog>
+#include <QSaveFile>
 
 #include "gui/RetroChessSettings.h"
+#include "gui/ChessGameHistory.h"
+#include "gui/ChessGameReviewDialog.h"
 #include "gui/RetroChessUserNotify.h"
 #include "gui/gxs/GxsIdTreeWidgetItem.h"
 
@@ -84,6 +87,20 @@ NEMainpage::NEMainpage(QWidget *parent, RetroChessNotify *notify) :
 	ui->pendingInvites->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
 	ui->pendingInvites->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
 	ui->pendingInvites->setIconSize(QSize(40, 40));
+	ui->gameHistory->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+	ui->gameHistory->header()->setSectionResizeMode(1, QHeaderView::Stretch);
+	ui->gameHistory->header()->setSectionResizeMode(2, QHeaderView::Stretch);
+	ui->gameHistory->header()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
+	ui->gameHistory->header()->setSectionResizeMode(4, QHeaderView::ResizeToContents);
+	connect(ui->reviewGameButton, &QPushButton::clicked,
+	        this, &NEMainpage::reviewSelectedGame);
+	connect(ui->exportGameButton, &QPushButton::clicked,
+	        this, &NEMainpage::exportSelectedGame);
+	connect(ui->deleteGameButton, &QPushButton::clicked,
+	        this, &NEMainpage::deleteSelectedGame);
+	connect(ui->gameHistory, &QTreeWidget::itemDoubleClicked,
+	        this, [this](QTreeWidgetItem *, int) { reviewSelectedGame(); });
+	refreshGameHistory();
 }
 
 NEMainpage::~NEMainpage()
@@ -491,18 +508,6 @@ void NEMainpage::NeMsgArrived(const RsPeerId &peer_id, QString str)
 		if (activeGames.contains(key))
 			activeGames.value(key)->applyGameAction(vmap.value("action").toString(), true);
 	}
-	// else if( type == "chess_reject") // other player rejected your invite (need to be finish)
-	else
-	{
-		QString output = QTime::currentTime().toString() +" ";
-		output+= QString::fromStdString(rsPeers->getPeerName(peer_id));
-		output+=": ";
-		output+=str;
-		// Any peer can feed this list; never let it grow without bound.
-		while (ui->netLogWidget->count() >= 200)
-			delete ui->netLogWidget->takeItem(0);
-		ui->netLogWidget->addItem(output);
-	}
 }
 
 void NEMainpage::create_chess_window(std::string peer_id, int player_id)
@@ -525,6 +530,7 @@ void NEMainpage::create_chess_window(std::string peer_id, int player_id)
 	        this, SLOT(requestRematchPeer(QString,int)));
 	connect(rcw, SIGNAL(gameClosed(QString)), this, SLOT(removeActiveGame(QString)));
 	connect(rcw, SIGNAL(gameEnded(QString)), this, SLOT(removeActiveGameListing(QString)));
+	connect(rcw, SIGNAL(gameReadyForHistory()), this, SLOT(archiveFinishedGame()));
 	rcw->show();
 
 	activeGames.insert(peer_id, rcw);
@@ -563,12 +569,99 @@ void NEMainpage::create_chess_window_gxs(const RsGxsId &gxs_id, int player_id)
             this, SLOT(requestRematchGxs(RsGxsId,int)));
     connect(win, SIGNAL(gameClosed(QString)), this, SLOT(removeActiveGame(QString)));
     connect(win, SIGNAL(gameEnded(QString)), this, SLOT(removeActiveGameListing(QString)));
+	connect(win, SIGNAL(gameReadyForHistory()), this, SLOT(archiveFinishedGame()));
     win->show();
 
     // Track the game so GXS moves can be routed to it
     std::string key = gxs_id.toStdString();
     activeGames.insert(key, win);
     ui->active_games->addItem(QString::fromStdString(key));
+}
+
+void NEMainpage::archiveFinishedGame()
+{
+	RetroChessWindow *window = qobject_cast<RetroChessWindow *>(sender());
+	if (!window) return;
+	ChessGameHistory::addGame(window->historyRecord());
+	refreshGameHistory();
+}
+
+void NEMainpage::refreshGameHistory()
+{
+	ui->gameHistory->clear();
+	const QVector<ChessGameRecord> games = ChessGameHistory::games();
+	for (const ChessGameRecord &game : games) {
+		QTreeWidgetItem *item = new QTreeWidgetItem(ui->gameHistory);
+		item->setData(0, Qt::UserRole, game.id);
+		item->setText(0, QLocale().toString(
+		        game.endedAt.toLocalTime(), QLocale::ShortFormat));
+		item->setText(1, game.whitePlayer);
+		item->setText(2, game.blackPlayer);
+		item->setText(3, game.result);
+		item->setText(4, QString::number(game.moves.size()));
+		item->setToolTip(3, game.reason);
+	}
+	const bool hasGames = !games.isEmpty();
+	ui->gameHistoryDescription->setText(hasGames
+	        ? tr("Double-click a saved game to replay every position.")
+	        : tr("No saved games yet. Finished and interrupted games will appear here."));
+	ui->reviewGameButton->setEnabled(hasGames);
+	ui->exportGameButton->setEnabled(hasGames);
+	ui->deleteGameButton->setEnabled(hasGames);
+	if (hasGames)
+		ui->gameHistory->setCurrentItem(ui->gameHistory->topLevelItem(0));
+}
+
+bool NEMainpage::selectedHistoryGame(ChessGameRecord &selected) const
+{
+	QTreeWidgetItem *item = ui->gameHistory->currentItem();
+	if (!item) return false;
+	const QString id = item->data(0, Qt::UserRole).toString();
+	for (const ChessGameRecord &game : ChessGameHistory::games())
+		if (game.id == id) {
+			selected = game;
+			return true;
+		}
+	return false;
+}
+
+void NEMainpage::reviewSelectedGame()
+{
+	ChessGameRecord game;
+	if (!selectedHistoryGame(game)) return;
+	ChessGameReviewDialog dialog(game, this);
+	dialog.exec();
+}
+
+void NEMainpage::exportSelectedGame()
+{
+	ChessGameRecord game;
+	if (!selectedHistoryGame(game)) return;
+	const QString path = QFileDialog::getSaveFileName(
+	        this, tr("Export chess game"),
+	        QString("%1-vs-%2.pgn").arg(game.whitePlayer, game.blackPlayer),
+	        tr("Portable Game Notation (*.pgn)"));
+	if (path.isEmpty()) return;
+	QSaveFile file(path);
+	if (!file.open(QIODevice::WriteOnly)
+	        || file.write(ChessGameHistory::toPgn(game).toUtf8()) < 0
+	        || !file.commit())
+		QMessageBox::warning(
+		        this, tr("Export chess game"),
+		        tr("The PGN file could not be saved."));
+}
+
+void NEMainpage::deleteSelectedGame()
+{
+	ChessGameRecord game;
+	if (!selectedHistoryGame(game)) return;
+	if (QMessageBox::question(
+	        this, tr("Delete saved game"),
+	        tr("Delete the saved game between %1 and %2?")
+	                .arg(game.whitePlayer, game.blackPlayer)) != QMessageBox::Yes)
+		return;
+	ChessGameHistory::removeGame(game.id);
+	refreshGameHistory();
 }
 
 void NEMainpage::setupMenuActions()

--- a/gui/NEMainpage.cpp
+++ b/gui/NEMainpage.cpp
@@ -51,6 +51,9 @@
 #include "gui/ChessGameReviewDialog.h"
 #include "gui/RetroChessUserNotify.h"
 #include "gui/gxs/GxsIdTreeWidgetItem.h"
+#include "gui/settings/rsharesettings.h"
+#include "gui/common/AvatarDefs.h"
+#include "util/HandleRichText.h"
 
 #include "gui/chat/ChatDialog.h"
 #include <retroshare/rsidentity.h>
@@ -87,11 +90,34 @@ NEMainpage::NEMainpage(QWidget *parent, RetroChessNotify *notify) :
 	ui->pendingInvites->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
 	ui->pendingInvites->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
 	ui->pendingInvites->setIconSize(QSize(40, 40));
-	ui->gameHistory->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
-	ui->gameHistory->header()->setSectionResizeMode(1, QHeaderView::Stretch);
-	ui->gameHistory->header()->setSectionResizeMode(2, QHeaderView::Stretch);
-	ui->gameHistory->header()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
-	ui->gameHistory->header()->setSectionResizeMode(4, QHeaderView::ResizeToContents);
+	QHeaderView *historyHeader = ui->gameHistory->header();
+	historyHeader->setSectionResizeMode(QHeaderView::Interactive);
+	historyHeader->setSectionsMovable(true);
+	historyHeader->setMinimumSectionSize(45);
+	const QByteArray historyHeaderState = Settings->valueFromGroup(
+	        "RetroChess", "GameHistoryHeaderState", QByteArray()).toByteArray();
+	if (!historyHeaderState.isEmpty())
+		historyHeader->restoreState(historyHeaderState);
+	else {
+		historyHeader->resizeSection(0, 165);
+		historyHeader->resizeSection(1, 210);
+		historyHeader->resizeSection(2, 210);
+		historyHeader->resizeSection(3, 85);
+		historyHeader->resizeSection(4, 75);
+	}
+	historyHeader->setStretchLastSection(true);
+	connect(historyHeader, &QHeaderView::sectionResized, this,
+	        [historyHeader](int, int, int) {
+		Settings->setValueToGroup(
+		        "RetroChess", "GameHistoryHeaderState", historyHeader->saveState());
+	});
+	connect(historyHeader, &QHeaderView::sectionMoved, this,
+	        [historyHeader](int, int, int) {
+		Settings->setValueToGroup(
+		        "RetroChess", "GameHistoryHeaderState", historyHeader->saveState());
+	});
+	ui->gameHistory->setIconSize(QSize(32, 32));
+	ui->gameHistory->setContextMenuPolicy(Qt::CustomContextMenu);
 	connect(ui->reviewGameButton, &QPushButton::clicked,
 	        this, &NEMainpage::reviewSelectedGame);
 	connect(ui->exportGameButton, &QPushButton::clicked,
@@ -100,6 +126,21 @@ NEMainpage::NEMainpage(QWidget *parent, RetroChessNotify *notify) :
 	        this, &NEMainpage::deleteSelectedGame);
 	connect(ui->gameHistory, &QTreeWidget::itemDoubleClicked,
 	        this, [this](QTreeWidgetItem *, int) { reviewSelectedGame(); });
+	connect(ui->gameHistory, &QTreeWidget::customContextMenuRequested,
+	        this, [this](const QPoint &position) {
+		QTreeWidgetItem *item = ui->gameHistory->itemAt(position);
+		if (!item) return;
+		ui->gameHistory->setCurrentItem(item);
+		QMenu menu(ui->gameHistory);
+		QAction *review = menu.addAction(tr("Review"));
+		QAction *exportPgn = menu.addAction(tr("Export PGN"));
+		menu.addSeparator();
+		QAction *remove = menu.addAction(tr("Delete"));
+		QAction *selected = menu.exec(ui->gameHistory->viewport()->mapToGlobal(position));
+		if (selected == review) reviewSelectedGame();
+		else if (selected == exportPgn) exportSelectedGame();
+		else if (selected == remove) deleteSelectedGame();
+	});
 	refreshGameHistory();
 }
 
@@ -591,15 +632,77 @@ void NEMainpage::refreshGameHistory()
 	ui->gameHistory->clear();
 	const QVector<ChessGameRecord> games = ChessGameHistory::games();
 	for (const ChessGameRecord &game : games) {
-		QTreeWidgetItem *item = new QTreeWidgetItem(ui->gameHistory);
+		QTreeWidgetItem *item = nullptr;
+		if (!game.whiteGxsId.isEmpty()) {
+			item = new GxsIdRSTreeWidgetItem(
+			        nullptr, GxsIdDetails::ICON_TYPE_AVATAR, true, ui->gameHistory);
+		} else item = new QTreeWidgetItem(ui->gameHistory);
 		item->setData(0, Qt::UserRole, game.id);
 		item->setText(0, QLocale().toString(
 		        game.endedAt.toLocalTime(), QLocale::ShortFormat));
 		item->setText(1, game.whitePlayer);
 		item->setText(2, game.blackPlayer);
+		auto setGxsIdentity = [item](
+		        int column, const QString &idText, const QString &storedName) {
+			if (idText.isEmpty()) return;
+			const RsGxsId id(idText.toStdString());
+			RsIdentityDetails details;
+			QPixmap pixmap;
+			QString name = storedName;
+			const bool detailsAvailable = rsIdentity->getIdDetails(id, details);
+			if (detailsAvailable) {
+				if (!details.mNickname.empty())
+					name = QString::fromUtf8(details.mNickname.c_str());
+				if (details.mAvatar.mSize == 0
+				        || !GxsIdDetails::loadPixmapFromData(
+				                details.mAvatar.mData, details.mAvatar.mSize,
+				                pixmap, GxsIdDetails::MEDIUM))
+					pixmap = GxsIdDetails::makeDefaultIcon(id, GxsIdDetails::MEDIUM);
+			} else pixmap = GxsIdDetails::makeDefaultIcon(id, GxsIdDetails::MEDIUM);
+			item->setText(column, name);
+			item->setData(column, Qt::UserRole, idText);
+			item->setIcon(column, QIcon(pixmap));
+
+			QPixmap tooltipPixmap;
+			if (!detailsAvailable || details.mAvatar.mSize == 0
+			        || !GxsIdDetails::loadPixmapFromData(
+			                details.mAvatar.mData, details.mAvatar.mSize,
+			                tooltipPixmap, GxsIdDetails::LARGE))
+				tooltipPixmap = GxsIdDetails::makeDefaultIcon(id, GxsIdDetails::LARGE);
+			QString tooltip = detailsAvailable
+			        ? GxsIdDetails::getComment(details) : QString();
+			if (tooltip.isEmpty())
+				tooltip = tr("Identity name: %1<br/>Identity Id: %2")
+				        .arg(name.toHtmlEscaped(), idText.toHtmlEscaped());
+			QString embeddedImage;
+			if (RsHtml::makeEmbeddedImage(
+			        tooltipPixmap.scaled(
+			                QSize(96, 96), Qt::KeepAspectRatio,
+			                Qt::SmoothTransformation).toImage(),
+			        embeddedImage, -1))
+				tooltip = QString("<table><tr><td>%1</td><td>%2</td></tr></table>")
+				        .arg(embeddedImage, tooltip);
+			item->setToolTip(column, tooltip);
+		};
+		setGxsIdentity(1, game.whiteGxsId, game.whitePlayer);
+		setGxsIdentity(2, game.blackGxsId, game.blackPlayer);
+		if (!game.whitePeerId.isEmpty()) {
+			QPixmap avatar;
+			AvatarDefs::getAvatarFromSslId(
+			        RsPeerId(game.whitePeerId.toStdString()), avatar);
+			if (!avatar.isNull()) item->setIcon(1, QIcon(avatar));
+		}
+		if (!game.blackPeerId.isEmpty()) {
+			QPixmap avatar;
+			AvatarDefs::getAvatarFromSslId(
+			        RsPeerId(game.blackPeerId.toStdString()), avatar);
+			if (!avatar.isNull()) item->setIcon(2, QIcon(avatar));
+		}
 		item->setText(3, game.result);
 		item->setText(4, QString::number(game.moves.size()));
 		item->setToolTip(3, game.reason);
+		for (int column = 0; column < ui->gameHistory->columnCount(); ++column)
+			item->setSizeHint(column, QSize(32, 40));
 	}
 	const bool hasGames = !games.isEmpty();
 	ui->gameHistoryDescription->setText(hasGames

--- a/gui/NEMainpage.h
+++ b/gui/NEMainpage.h
@@ -87,6 +87,7 @@ private slots:
 	void removeActiveGameListing(QString gameId);
 	void autoJoinOfficialLobby();
 	void officialLobbyNewMessage(ChatWidget *chatWidget);
+	void archiveFinishedGame();
 private:
 	Ui::NEMainpage *ui;
 	RetroChessNotify *mNotify;
@@ -102,6 +103,11 @@ private:
 	void addGxsInvitation(const RsGxsId &gxs_id);
 	void removePendingInvitation(const QString &key);
 	void showOfficialLobby();
+	void refreshGameHistory();
+	bool selectedHistoryGame(ChessGameRecord &game) const;
+	void reviewSelectedGame();
+	void exportSelectedGame();
+	void deleteSelectedGame();
 	void showEvent(QShowEvent *event) override;
 };
 

--- a/gui/NEMainpage.ui
+++ b/gui/NEMainpage.ui
@@ -209,26 +209,51 @@
       </attribute>
       <layout class="QVBoxLayout" name="gameHistoryLayout">
        <item>
-        <widget class="QLabel" name="gameHistoryDescription">
-         <property name="text">
-          <string>Saved games will appear here for replay and analysis.</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-       </widget>
-       </item>
-       <item>
         <layout class="QHBoxLayout" name="gameHistoryActions">
          <item>
+          <widget class="QLabel" name="gameHistoryDescription">
+           <property name="text">
+            <string>Saved games will appear here for replay and analysis.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="gameHistoryActionsSpacer">
-           <property name="orientation"><enum>Qt::Horizontal</enum></property>
-           <property name="sizeHint" stdset="0"><size><width>40</width><height>20</height></size></property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
           </spacer>
          </item>
-         <item><widget class="QPushButton" name="reviewGameButton"><property name="text"><string>Review</string></property></widget></item>
-         <item><widget class="QPushButton" name="exportGameButton"><property name="text"><string>Export PGN</string></property></widget></item>
-         <item><widget class="QPushButton" name="deleteGameButton"><property name="text"><string>Delete</string></property></widget></item>
+         <item>
+          <widget class="QPushButton" name="reviewGameButton">
+           <property name="text">
+            <string>Review</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="exportGameButton">
+           <property name="text">
+            <string>Export PGN</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="deleteGameButton">
+           <property name="text">
+            <string>Delete</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>

--- a/gui/NEMainpage.ui
+++ b/gui/NEMainpage.ui
@@ -203,13 +203,71 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab_2">
+     <widget class="QWidget" name="gameHistoryTab">
       <attribute name="title">
-       <string>Net log</string>
+       <string>Game History</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_2">
-       <item row="0" column="0">
-        <widget class="QListWidget" name="netLogWidget"/>
+      <layout class="QVBoxLayout" name="gameHistoryLayout">
+       <item>
+        <widget class="QLabel" name="gameHistoryDescription">
+         <property name="text">
+          <string>Saved games will appear here for replay and analysis.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+       </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="gameHistoryActions">
+         <item>
+          <spacer name="gameHistoryActionsSpacer">
+           <property name="orientation"><enum>Qt::Horizontal</enum></property>
+           <property name="sizeHint" stdset="0"><size><width>40</width><height>20</height></size></property>
+          </spacer>
+         </item>
+         <item><widget class="QPushButton" name="reviewGameButton"><property name="text"><string>Review</string></property></widget></item>
+         <item><widget class="QPushButton" name="exportGameButton"><property name="text"><string>Export PGN</string></property></widget></item>
+         <item><widget class="QPushButton" name="deleteGameButton"><property name="text"><string>Delete</string></property></widget></item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QTreeWidget" name="gameHistory">
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="rootIsDecorated">
+          <bool>false</bool>
+         </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
+         <column>
+          <property name="text">
+           <string>Date</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>White</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Black</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Result</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Moves</string>
+          </property>
+         </column>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/gui/chess.cpp
+++ b/gui/chess.cpp
@@ -2737,6 +2737,15 @@ ChessGameRecord RetroChessWindow::historyRecord() const
 	game.endedAt = QDateTime::currentDateTimeUtc();
 	game.whitePlayer = QString::fromUtf8(p2name.c_str());
 	game.blackPlayer = QString::fromUtf8(p1name.c_str());
+	if (mIsGxs) {
+		const RsGxsId whiteId = m_localplayer_turn == 1 ? mOwnGxsId : mGxsId;
+		const RsGxsId blackId = m_localplayer_turn == 0 ? mOwnGxsId : mGxsId;
+		game.whiteGxsId = QString::fromStdString(whiteId.toStdString());
+		game.blackGxsId = QString::fromStdString(blackId.toStdString());
+	} else {
+		game.whitePeerId = QString::fromStdString(p2id.toStdString());
+		game.blackPeerId = QString::fromStdString(p1id.toStdString());
+	}
 	game.result = m_gameResult;
 	game.reason = m_gameEndReason;
 	game.moves = m_move_history;

--- a/gui/chess.cpp
+++ b/gui/chess.cpp
@@ -72,7 +72,9 @@ RetroChessWindow::RetroChessWindow(const RsGxsId &gxsId, int player, QWidget *pa
     m_gameStatusBar(nullptr),
     m_debugWidget(nullptr),
     m_fullmoveNumber(1),
-    m_desynchronized(false)
+    m_desynchronized(false),
+    m_gameStartedAt(QDateTime::currentDateTimeUtc()),
+    m_gameArchived(false)
 {
     QString player_str; 
     if (player == 1) {
@@ -173,7 +175,9 @@ RetroChessWindow::RetroChessWindow(std::string peerid, int player, QWidget *pare
 	m_gameStatusBar(nullptr),
 	m_debugWidget(nullptr),
 	m_fullmoveNumber(1),
-	m_desynchronized(false)
+	m_desynchronized(false),
+	m_gameStartedAt(QDateTime::currentDateTimeUtc()),
+	m_gameArchived(false)
 	//ui(new Ui::RetroChessWindow)
 {
 	m_ui->setupUi( this );
@@ -580,6 +584,8 @@ void RetroChessWindow::initAccessories()
 
 void RetroChessWindow::closeEvent(QCloseEvent *event)
 {
+	if (!m_gameArchived)
+		completeGameHistory("*", tr("Game window closed before completion"));
     // send leave message
     if (!m_suppressLeave && mIsGxs) {
         rsRetroChess->player_leave_gxs(this->mGxsId);
@@ -1951,6 +1957,10 @@ void RetroChessWindow::showGameResultDialog(bool localWon, bool draw, const QStr
     if (m_resultPopupShown)
         return;
     m_resultPopupShown = true;
+	const int winningColor = localWon ? m_localplayer_turn : 1 - m_localplayer_turn;
+	completeGameHistory(
+	        draw ? "1/2-1/2" : (winningColor == 1 ? "1-0" : "0-1"),
+	        !reason.isEmpty() ? reason : (draw ? tr("Draw") : tr("Resignation")));
 	if (!draw && m_victorySound && RetroChessSettings::gameResultSoundEnabled()) {
 		m_victorySound->stop();
 		m_victorySound->setPosition(0);
@@ -2425,6 +2435,7 @@ void RetroChessWindow::stopForDesynchronization(const QString &reason)
 	if (m_desynchronized) return;
 	m_desynchronized = true;
 	m_flag_finished = 7;
+	completeGameHistory("*", tr("Boards out of sync: %1").arg(reason));
 	appendDebugEvent("DESYNC: " + reason + " Local FEN=" + currentFen());
 	showGameStatus(tr("Boards are out of sync — game paused"));
 	QMessageBox::critical(this, tr("Chess synchronization error"),
@@ -2592,6 +2603,7 @@ void RetroChessWindow::applyGameAction(const QString &action, bool remote)
 		m_suppressLeave = true;
 		m_ui->m_status_bar->setText(remote ? tr("Opponent aborted the game") : tr("Game aborted"));
 		m_ui->m_status_bar->show();
+		completeGameHistory("*", remote ? tr("Opponent aborted") : tr("Game aborted"));
 		emit gameEnded(QString::fromStdString(mPeerId));
 	} else if (action == "resign") {
 		m_flag_finished = 1;
@@ -2687,6 +2699,9 @@ void RetroChessWindow::showPlayerLeaveMsg()
 {
 	// Stop all local interaction as soon as the opponent leaves.
 	m_flag_finished = 1;
+	completeGameHistory(
+	        m_localplayer_turn == 1 ? "1-0" : "0-1",
+	        tr("Opponent left the game"));
     QString name;
     if (mIsGxs) {
         // Resolve GXS nickname
@@ -2704,6 +2719,29 @@ void RetroChessWindow::showPlayerLeaveMsg()
     QString status_msg = name + tr(" has left");
     m_ui->m_status_bar->setText(status_msg);
     m_ui->m_status_bar->setVisible(true);
+}
+
+void RetroChessWindow::completeGameHistory(const QString &result, const QString &reason)
+{
+	if (m_gameArchived) return;
+	m_gameArchived = true;
+	m_gameResult = result;
+	m_gameEndReason = reason;
+	emit gameReadyForHistory();
+}
+
+ChessGameRecord RetroChessWindow::historyRecord() const
+{
+	ChessGameRecord game;
+	game.startedAt = m_gameStartedAt;
+	game.endedAt = QDateTime::currentDateTimeUtc();
+	game.whitePlayer = QString::fromUtf8(p2name.c_str());
+	game.blackPlayer = QString::fromUtf8(p1name.c_str());
+	game.result = m_gameResult;
+	game.reason = m_gameEndReason;
+	game.moves = m_move_history;
+	game.positions = QStringList(m_boardHistory.begin(), m_boardHistory.end());
+	return game;
 }
 
 void RetroChessWindow::playerTurnNotice()

--- a/gui/chess.h
+++ b/gui/chess.h
@@ -34,6 +34,8 @@
 #include <QStringList>
 #include <QVector>
 
+#include "ChessGameHistory.h"
+
 class QLabel;
 class QTableWidget;
 class QMediaPlayer;
@@ -179,6 +181,7 @@ public:
 	void stopForDesynchronization(const QString &reason);
 	void showGameStatus(const QString &status);
 	void refreshBoardTheme();
+	ChessGameRecord historyRecord() const;
     void drawLastMove();
     void clearLastMove();
 
@@ -187,12 +190,18 @@ public:
     void playerTurnNotice();
 	void closeForRematch();
 	void showGameResultDialog(bool localWon, bool draw = false, const QString &reason = QString());
+	void completeGameHistory(const QString &result, const QString &reason);
+	QDateTime m_gameStartedAt;
+	QString m_gameResult;
+	QString m_gameEndReason;
+	bool m_gameArchived;
 
 signals:
 	void rematchRequested(const RsGxsId &gxsId, int localColor);
 	void rematchRequestedPeer(QString peerId, int localColor);
 	void gameClosed(QString gameId);
 	void gameEnded(QString gameId);
+	void gameReadyForHistory();
 };
 
 


### PR DESCRIPTION
New games are now automatically saved when they end through:
- Checkmate
- Stalemate and rule-based draws
- Accepted draw offers
- Resignation
- Abort
- Opponent disconnect
- Desynchronization
- Closing an unfinished game window The Game History tab now supports:
- Date, White, Black, result, and move count
- Persistent history across RetroShare restarts
- Double-click or Review to replay positions
- First, previous, next, and last move navigation
- Move-table position selection
- PGN export
- Deleting saved games
- Up to 500 saved games