### PR TITLE
Implemented Reject in the chess invitation panel.

### DIFF
--- a/docs/MsgProtocol.md
+++ b/docs/MsgProtocol.md
@@ -1,5 +1,19 @@
 Message includeing controls, invite/accept.
 
+## GXS invitation replies
+
+Invitations use the RetroChess service over a secured GXS tunnel; no distant
+chat is required. `{"type":"chess_invite"}` prompts the receiver to Accept or
+Reject in the chess page. Accept replies with `{"type":"chess_accept"}`;
+Reject replies with `{"type":"chess_reject"}` on the same tunnel.
+
+After the rejection is queued, the receiver clears the incoming invitation and
+its UI actions. If queuing fails, the invitation remains available for retry.
+The sender clears its outgoing invitation and displays "Invitation declined."
+Unsolicited or duplicate rejection packets are ignored. A separate incoming
+invitation from the same identity is preserved. The tunnel remains available.
+Older versions that do not handle `chess_reject` will not display the decline.
+
 # peer messge:
 qvm peer message assembly in a `QVariantMap`, format as `key`-`value`, usage:
 

--- a/gui/NEMainpage.cpp
+++ b/gui/NEMainpage.cpp
@@ -34,6 +34,7 @@
 #include <string>
 #include <QMenu>
 #include <QMessageBox>
+#include <QMessageBox>
 #include <QToolButton>
 #include <QTimer>
 #include <QShowEvent>
@@ -41,6 +42,7 @@
 #include <QCoreApplication>
 #include <QLocale>
 #include <QHeaderView>
+#include <QFontMetricsF>
 #include <QHBoxLayout>
 #include <QPushButton>
 #include <QTreeWidgetItem>
@@ -119,6 +121,15 @@ NEMainpage::NEMainpage(QWidget *parent, RetroChessNotify *notify) :
 	// The inviter is White; the participant who accepts is Black.
 	connect(mNotify, SIGNAL(chessStartGxs(RsGxsId)), this, SLOT(chessStartGxsAsBlack(RsGxsId)));
 	connect(mNotify, SIGNAL(chessAcceptedGxs(RsGxsId)), this, SLOT(chessStartGxs(RsGxsId)));
+	connect(mNotify, &RetroChessNotify::chessRejectedGxs, this,
+	        [this](const RsGxsId &gxsId) {
+		QMessageBox *message = new QMessageBox(QMessageBox::Information,
+		        tr("Chess invitation"), tr("Invitation declined."),
+		        QMessageBox::Ok, this);
+		message->setInformativeText(QString::fromStdString(gxsId.toStdString()));
+		message->setAttribute(Qt::WA_DeleteOnClose);
+		message->show();
+	});
 	connect(mNotify, SIGNAL(chessMoveGxs(RsGxsId,int,int,int)), this, SLOT(chessMoveGxs(RsGxsId,int,int,int)));
 	connect(mNotify, SIGNAL(chessPlayerLeftGxs(RsGxsId)), this, SLOT(chessPlayerLeftGxs(RsGxsId)));
 	connect(mNotify, SIGNAL(chessRematchGxs(RsGxsId,int)), this, SLOT(chessRematchGxs(RsGxsId,int)));
@@ -131,8 +142,23 @@ NEMainpage::NEMainpage(QWidget *parent, RetroChessNotify *notify) :
 	ui->pendingInvites->header()->setSectionResizeMode(0, QHeaderView::Stretch);
 	ui->pendingInvites->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
 	ui->pendingInvites->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
-	ui->pendingInvites->setIconSize(QSize(40, 40));
-	ui->availablePlayers->setIconSize(QSize(32, 32));
+	QFontMetricsF fontMetrics(ui->contactstreeWidget->font());
+
+	int iconHeight = fontMetrics.height() * 2.0;
+	ui->availablePlayers->setIconSize(QSize(iconHeight, iconHeight));
+	ui->pendingInvites->setIconSize(QSize(iconHeight, iconHeight));
+
+	ui->contactstreeWidget->setFixedWidth(260);
+	ui->contactstreeWidget->setIconSize(QSize(iconHeight, iconHeight));
+	ui->contactstreeWidget->setRootIsDecorated(false);
+	ui->contactstreeWidget->setAlternatingRowColors(false);
+	ui->contactstreeWidget->setSortingEnabled(true);
+	ui->contactstreeWidget->sortItems(0, Qt::AscendingOrder);
+	ui->contactstreeWidget->setToolTip(tr("Right-click a contact to invite them to chess."));
+	ui->contactstreeWidget->setContextMenuPolicy(Qt::CustomContextMenu);
+	connect(ui->contactstreeWidget, &QTreeWidget::customContextMenuRequested, this,
+	        &NEMainpage::ContactsCustomPopupMenu);
+
 	ui->availablePlayers->header()->setSectionResizeMode(0, QHeaderView::Stretch);
 	ui->availablePlayers->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
 	ui->availablePlayers->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
@@ -140,9 +166,16 @@ NEMainpage::NEMainpage(QWidget *parent, RetroChessNotify *notify) :
 	mAvailablePlayersTimer->setInterval(3000);
 	connect(mAvailablePlayersTimer, &QTimer::timeout,
 	        this, &NEMainpage::refreshAvailablePlayers);
+	connect(mAvailablePlayersTimer, &QTimer::timeout,
+	        this, &NEMainpage::refreshContacts);
 	mAvailablePlayersTimer->start();
 	connect(ui->tabWidget, &QTabWidget::currentChanged,
-	        this, [this](int) { refreshAvailablePlayers(); });
+	        this, [this](int) {
+		refreshAvailablePlayers();
+		mNextContactsRefresh = 0;
+		refreshContacts();
+	});
+	refreshContacts();
 	QHeaderView *historyHeader = ui->gameHistory->header();
 	historyHeader->setSectionResizeMode(QHeaderView::Interactive);
 	historyHeader->setSectionsMovable(true);
@@ -214,6 +247,103 @@ NEMainpage::NEMainpage(QWidget *parent, RetroChessNotify *notify) :
 	}
 }
 
+void NEMainpage::ContactsCustomPopupMenu(QPoint position)
+{
+	QTreeWidgetItem *item = ui->contactstreeWidget->itemAt(position);
+	if (!item) return;
+	ui->contactstreeWidget->setCurrentItem(item);
+	// Copy the identity: contact refreshes may remove the row while the menu is open.
+	const QString endpoint = item->data(0, Qt::UserRole).toString();
+	QMenu contextMnu(this);
+	QAction *invite = contextMnu.addAction(tr("Invite to chess"));
+	invite->setEnabled(!mGameSessions->contains(endpoint));
+	if (contextMnu.exec(ui->contactstreeWidget->viewport()->mapToGlobal(position)) != invite)
+		return;
+	const RsGxsId targetGxsId(endpoint.toStdString());
+	if (!rsIdentity || rsIdentity->isOwnId(targetGxsId)
+	        || mGameSessions->contains(endpoint)) return;
+	if (!rsRetroChess->sendInviteToGxs(targetGxsId)) {
+		QMessageBox::warning(this, tr("Chess invitation"),
+		        tr("The chess invitation could not be sent."));
+		return;
+	}
+	refreshAvailablePlayers();
+}
+
+void NEMainpage::refreshContacts()
+{
+	if (!rsIdentity) return;
+	if (!mContactsRequestPending) {
+		if (QDateTime::currentMSecsSinceEpoch() < mNextContactsRefresh) return;
+		RsTokReqOptions options;
+		options.mReqType = GXS_REQUEST_TYPE_GROUP_META;
+		mContactsRequestPending = rsIdentity->requestGroupInfo(mContactsToken, options);
+		return;
+	}
+	const auto status = rsIdentity->getTokenService()->requestStatus(mContactsToken);
+	if (status != RsTokenService::COMPLETE) {
+		if (status == RsTokenService::FAILED || status == RsTokenService::CANCELLED) {
+			rsIdentity->getTokenService()->cancelRequest(mContactsToken);
+			mContactsRequestPending = false;
+		}
+		return;
+	}
+	mContactsRequestPending = false;
+	mNextContactsRefresh = QDateTime::currentMSecsSinceEpoch() + 30000;
+	std::list<RsGroupMetaData> identities;
+	if (!rsIdentity->getGroupSummary(mContactsToken, identities)) return;
+	QMap<QString, RsGxsId> contacts;
+	for (const auto &identity : identities) {
+		const RsGxsId id(identity.mGroupId.toStdString());
+		if (!id.isNull() && !rsIdentity->isOwnId(id) && rsIdentity->isARegularContact(id))
+			contacts.insert(QString::fromStdString(id.toStdString()), id);
+	}
+	// Retain rows and refresh their pixmaps directly, without the identity item's
+	// font-sized decoration callback overwriting the larger avatar.
+	QMap<QString, QTreeWidgetItem *> rows;
+	for (int row = ui->contactstreeWidget->topLevelItemCount() - 1; row >= 0; --row) {
+		QTreeWidgetItem *item = ui->contactstreeWidget->topLevelItem(row);
+		const QString key = item->data(0, Qt::UserRole).toString();
+		if (!contacts.contains(key)) delete item;
+		else rows.insert(key, item);
+	}
+	ui->contactstreeWidget->setSortingEnabled(false);
+	for (auto it = contacts.constBegin(); it != contacts.constEnd(); ++it) {
+		QTreeWidgetItem *item = rows.value(it.key());
+		if (!item) item = new QTreeWidgetItem(ui->contactstreeWidget);
+		const RsGxsId &id = it.value();
+		RsIdentityDetails details;
+		const bool detailsAvailable = rsIdentity->getIdDetails(id, details);
+		QString name = it.key();
+		if (detailsAvailable && !details.mNickname.empty())
+			name = QString::fromUtf8(details.mNickname.c_str());
+		QPixmap pixmap;
+		if (!detailsAvailable || details.mAvatar.mSize == 0
+		        || !GxsIdDetails::loadPixmapFromData(details.mAvatar.mData,
+		                details.mAvatar.mSize, pixmap, GxsIdDetails::MEDIUM))
+			pixmap = GxsIdDetails::makeDefaultIcon(id, GxsIdDetails::MEDIUM);
+		item->setText(0, name);
+		item->setIcon(0, QIcon(pixmap));
+		item->setData(0, Qt::UserRole, it.key());
+		QPixmap tooltipPixmap;
+		if (!detailsAvailable || details.mAvatar.mSize == 0
+		        || !GxsIdDetails::loadPixmapFromData(details.mAvatar.mData,
+		                details.mAvatar.mSize, tooltipPixmap, GxsIdDetails::LARGE))
+			tooltipPixmap = GxsIdDetails::makeDefaultIcon(id, GxsIdDetails::LARGE);
+		QString tooltip = detailsAvailable ? GxsIdDetails::getComment(details) : QString();
+		if (tooltip.isEmpty())
+			tooltip = tr("Identity name: %1<br/>Identity Id: %2")
+			        .arg(name.toHtmlEscaped(), it.key().toHtmlEscaped());
+		QString embeddedImage;
+		if (RsHtml::makeEmbeddedImage(tooltipPixmap.scaled(QSize(96, 96),
+		        Qt::KeepAspectRatio, Qt::SmoothTransformation).toImage(), embeddedImage, -1))
+			tooltip = QString("<table><tr><td>%1</td><td>%2</td></tr></table>")
+			        .arg(embeddedImage, tooltip);
+		item->setToolTip(0, tooltip);
+	}
+	ui->contactstreeWidget->setSortingEnabled(true);
+}
+
 void NEMainpage::refreshAvailablePlayers()
 {
 	ui->availablePlayers->setSortingEnabled(false);
@@ -221,15 +351,24 @@ void NEMainpage::refreshAvailablePlayers()
 	const auto peers = rsRetroChess->availableChessPeers();
 	for (const RsRetroChessAvailablePeer &peer : peers) {
 		if (!peer.gxs) continue;
-		GxsIdRSTreeWidgetItem *item = new GxsIdRSTreeWidgetItem(
-		        nullptr, GxsIdDetails::ICON_TYPE_AVATAR, true,
-		        ui->availablePlayers);
-		item->setId(RsGxsId(peer.endpointId.toStdString()), 0, true);
+		QTreeWidgetItem *item = new QTreeWidgetItem(ui->availablePlayers);
+		const RsGxsId id(peer.endpointId.toStdString());
+		RsIdentityDetails details;
+		const bool detailsAvailable = rsIdentity && rsIdentity->getIdDetails(id, details);
+		QString name = peer.endpointId;
+		if (detailsAvailable && !details.mNickname.empty())
+			name = QString::fromUtf8(details.mNickname.c_str());
+		QPixmap pixmap;
+		if (!detailsAvailable || details.mAvatar.mSize == 0
+		        || !GxsIdDetails::loadPixmapFromData(details.mAvatar.mData,
+		                details.mAvatar.mSize, pixmap, GxsIdDetails::MEDIUM))
+			pixmap = GxsIdDetails::makeDefaultIcon(id, GxsIdDetails::MEDIUM);
+		item->setText(0, name);
+		item->setIcon(0, QIcon(pixmap));
+		if (detailsAvailable) item->setToolTip(0, GxsIdDetails::getComment(details));
 		item->setData(0, Qt::UserRole, peer.endpointId);
 		item->setText(3, tr("GXS identity"));
 		item->setText(2, peer.tunnelReady ? tr("Ready") : tr("Connecting"));
-		for (int column = 0; column < 4; ++column)
-			item->setSizeHint(column, QSize(32, 38));
 
 		QPushButton *invite = new QPushButton(tr("Invite"), ui->availablePlayers);
 		invite->setFixedHeight(28);
@@ -259,6 +398,8 @@ void NEMainpage::refreshAvailablePlayers()
 
 NEMainpage::~NEMainpage()
 {
+	if (mContactsRequestPending && rsIdentity)
+		rsIdentity->getTokenService()->cancelRequest(mContactsToken);
 	mGameSessions->closeAll();
 	delete ui;
 }
@@ -441,10 +582,10 @@ void NEMainpage::addGxsInvitation(const RsGxsId &gxs_id)
 	QPushButton *accept = new QPushButton(tr("Accept"), actions);
 	accept->setStyleSheet(invitationButtonStyle());
 	accept->setFixedHeight(28);
-	QPushButton *ignore = new QPushButton(tr("Ignore"), actions);
-	ignore->setFixedHeight(28);
+	QPushButton *reject = new QPushButton(tr("Reject"), actions);
+	reject->setFixedHeight(28);
 	actionsLayout->addWidget(accept);
-	actionsLayout->addWidget(ignore);
+	actionsLayout->addWidget(reject);
 	ui->pendingInvites->setItemWidget(item, 2, actions);
 	mPendingInvites.insert(key, item);
 	ui->pendingInvitesBox->show();
@@ -459,10 +600,17 @@ void NEMainpage::addGxsInvitation(const RsGxsId &gxs_id)
 		removePendingInvitation(key);
 		mNotify->notifyChessStartGxs(gxs_id);
 	});
-	connect(ignore, &QPushButton::clicked, this, [this, gxs_id, key]() {
-		rsRetroChess->clearInviteGxs(gxs_id);
+	connect(reject, &QPushButton::clicked, this, [this, gxs_id, key]() {
+		if (!rsRetroChess->hasInviteFromGxs(gxs_id)) {
+			removePendingInvitation(key);
+			return;
+		}
+		if (!rsRetroChess->rejectedInviteGxs(gxs_id)) {
+			QMessageBox::warning(this, tr("Chess invitation"),
+			        tr("The rejection could not be sent. Please try again."));
+			return;
+		}
 		removePendingInvitation(key);
-		mNotify->notifyChessInviteClearedGxs(gxs_id);
 	});
 }
 

--- a/gui/NEMainpage.h
+++ b/gui/NEMainpage.h
@@ -93,6 +93,8 @@ private slots:
 	void officialLobbyNewMessage(ChatWidget *chatWidget);
 	void archiveFinishedGame();
 	void refreshAvailablePlayers();
+	void refreshContacts();
+	void ContactsCustomPopupMenu(QPoint position);
 private:
 	Ui::NEMainpage *ui;
 	RetroChessNotify *mNotify;
@@ -101,6 +103,9 @@ private:
 	QTimer *mAvailablePlayersTimer;
 	ChatDialog *mOfficialLobbyDialog;
 	unsigned int mLobbyUnreadCount;
+	uint32_t mContactsToken = 0;
+	bool mContactsRequestPending = false;
+	qint64 mNextContactsRefresh = 0;
 
 	QMap<QString, QTreeWidgetItem*> mPendingInvites;
 	QSet<QString> mUnreadInviteKeys;

--- a/gui/NEMainpage.ui
+++ b/gui/NEMainpage.ui
@@ -207,15 +207,27 @@
       <attribute name="title">
        <string>Available Players</string>
       </attribute>
-      <layout class="QVBoxLayout" name="availablePlayersLayout">
-       <item>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0" rowspan="2">
+        <widget class="QTreeWidget" name="contactstreeWidget">
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectItems</enum>
+         </property>
+         <column>
+          <property name="text">
+           <string>Contacts</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+       <item row="0" column="1">
         <widget class="QLabel" name="availablePlayersDescription">
          <property name="text">
           <string>GXS identities connected through a RetroChess tunnel.</string>
          </property>
         </widget>
        </item>
-       <item>
+       <item row="1" column="1">
         <widget class="QTreeWidget" name="availablePlayers">
          <property name="alternatingRowColors">
           <bool>true</bool>

--- a/gui/RetroChessNotify.cpp
+++ b/gui/RetroChessNotify.cpp
@@ -79,6 +79,11 @@ void RetroChessNotify::notifyChessAcceptedGxs(const RsGxsId &gxs_id)
 	emit chessAcceptedGxs(gxs_id);
 }
 
+void RetroChessNotify::notifyChessRejectedGxs(const RsGxsId &gxs_id)
+{
+	emit chessRejectedGxs(gxs_id);
+}
+
 void RetroChessNotify::notifyGxsTunnelClosed(const RsGxsId &gxs_id)
 {
 	emit gxsTunnelClosed(gxs_id);

--- a/gui/RetroChessNotify.h
+++ b/gui/RetroChessNotify.h
@@ -51,6 +51,7 @@ public:
 	void notifyGxsTunnelReady(const RsGxsId &gxs_id);
 	/** Notify the inviter that the remote player explicitly accepted */
 	void notifyChessAcceptedGxs(const RsGxsId &gxs_id);
+	void notifyChessRejectedGxs(const RsGxsId &gxs_id);
 
 	/** Notify the UI that a GXS tunnel has been closed/lost */
 	void notifyGxsTunnelClosed(const RsGxsId &gxs_id);
@@ -69,6 +70,7 @@ signals:
 	void chessMoveGxs(const RsGxsId &gxs_id, int col, int row, int count);
 	void gxsTunnelReady(const RsGxsId &gxs_id);
 	void chessAcceptedGxs(const RsGxsId &gxs_id);
+	void chessRejectedGxs(const RsGxsId &gxs_id);
 	void gxsTunnelClosed(const RsGxsId &gxs_id);
 	void chessPlayerLeftGxs(const RsGxsId &gxs_id);
 	void chessRematchGxs(const RsGxsId &gxs_id, int remoteColor);

--- a/gui/toaster/ChessToaster.cpp
+++ b/gui/toaster/ChessToaster.cpp
@@ -76,6 +76,14 @@ void ChessToaster::initialise(const QString &playerName, bool actionable)
 	connect(ui.toasterButton, &QPushButton::clicked,
 	        this, &ChessToaster::acceptInvite);
 	connect(ui.closeButton, &QPushButton::clicked, this, &QWidget::hide);
+	if (mNotify && !mGxsId.isNull())
+		connect(mNotify, &RetroChessNotify::chessInviteClearedGxs, this,
+		        [this](const RsGxsId &gxsId) {
+			if (gxsId == mGxsId) {
+				ui.toasterButton->setEnabled(false);
+				hide();
+			}
+		});
 }
 
 void ChessToaster::acceptInvite()

--- a/gui/toaster/RetroChessToasterNotify.cpp
+++ b/gui/toaster/RetroChessToasterNotify.cpp
@@ -42,6 +42,11 @@ RetroChessToasterNotify::RetroChessToasterNotify(
         RetroChessNotify *notify, QObject *parent)
     : ToasterNotify(parent), mNotify(notify), mInviteSound(new QMediaPlayer(this))
 {
+	connect(mNotify, &RetroChessNotify::chessInviteClearedGxs, this,
+	        [this](const RsGxsId &gxsId) {
+		for (int i = mPending.size() - 1; i >= 0; --i)
+			if (mPending.at(i).gxsId == gxsId) mPending.removeAt(i);
+	});
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	mInviteSound->setAudioOutput(new QAudioOutput(mInviteSound));
 	mInviteSound->setSource(QUrl("qrc:/sound/ping.mp3"));

--- a/interface/rsRetroChess.h
+++ b/interface/rsRetroChess.h
@@ -87,6 +87,7 @@ class RsRetroChess
 	virtual bool sendInviteToGxs(const RsGxsId &gxsId) = 0;
 	//virtual void addChessFriend(const RsGxsId &gxsId) = 0;
 	virtual void acceptedInviteGxs(const RsGxsId &gxsId) = 0;
+	virtual bool rejectedInviteGxs(const RsGxsId &gxsId) = 0;
 	virtual void clearInviteGxs(const RsGxsId &gxsId) = 0;
 	virtual bool hasInviteFromGxs(const RsGxsId &gxsId) = 0;
 	virtual RsGxsId ownGxsIdForPeer(const RsGxsId &gxsId) = 0;

--- a/services/p3RetroChess.cc
+++ b/services/p3RetroChess.cc
@@ -605,6 +605,26 @@ void p3RetroChess::acceptedInviteGxs(const RsGxsId &gxsId)
     }
 }
 
+bool p3RetroChess::rejectedInviteGxs(const RsGxsId &gxsId)
+{
+    RsGxsTunnelId tunnelId;
+    {
+        RsStackMutex stack(mRetroChessMtx);
+        if (mInvitesFromGxs.count(gxsId) == 0) return false;
+        auto it = mActiveTunnels.find(gxsId);
+        if (it == mActiveTunnels.end() || !mGxsTunnels) return false;
+        tunnelId = it->second;
+    }
+    const std::string reply = "{\"type\":\"chess_reject\"}";
+    // Keep the invitation available for retry if the transport cannot queue it.
+    if (!mGxsTunnels->sendData(tunnelId, RETRO_CHESS_GXS_TUNNEL_SERVICE_ID,
+            reinterpret_cast<const uint8_t*>(reply.data()), reply.size()))
+        return false;
+    clearInviteGxs(gxsId);
+    mNotify->notifyChessInviteClearedGxs(gxsId);
+    return true;
+}
+
 void p3RetroChess::clearInviteGxs(const RsGxsId &gxsId)
 {
     RsStackMutex stack(mRetroChessMtx);
@@ -855,13 +875,15 @@ void p3RetroChess::handleGxsTick()
             }
             ready.push_back(it->first);
         }
-        // Check for "Closed/Failed" status
-        else if (tinfo.tunnel_status == RsGxsTunnelService::RS_GXS_TUNNEL_STATUS_REMOTELY_CLOSED ||
-                 tinfo.tunnel_status == RsGxsTunnelService::RS_GXS_TUNNEL_STATUS_TUNNEL_DN) {
+        // TUNNEL_DN is also the engine's initial, still-connecting state.
+        // Keep the invitation queued until CAN_TALK; only an explicit remote
+        // close cancels a pending connection.
+        else if (tinfo.tunnel_status == RsGxsTunnelService::RS_GXS_TUNNEL_STATUS_REMOTELY_CLOSED) {
             RsStackMutex stack(mRetroChessMtx); /****** LOCKED MUTEX *******/
             auto pit = mPendingTunnels.find(it->first);
             if (pit != mPendingTunnels.end() && pit->second == it->second) {
                 mPendingGxsInvites.erase(it->first); // discard queued invite
+                mInvitesToGxs.erase(it->first);
                 mPendingTunnels.erase(pit);
             }
         }
@@ -937,6 +959,19 @@ void p3RetroChess::handleRawData(const RsGxsId& gxs_id,
         }
         std::cout << "Chess: Received accept from GXS " << sender_id << std::endl;
         mNotify->notifyChessAcceptedGxs(sender_id);
+
+    } else if (type == "chess_reject") {
+        {
+            RsStackMutex stack(mRetroChessMtx);
+            // Ignore unsolicited or duplicate replies. A rejection only
+            // resolves our outgoing invite, not a crossed incoming invite.
+            if (mInvitesToGxs.erase(sender_id) == 0) return;
+            auto pending = mPendingGxsInvites.find(sender_id);
+            if (pending != mPendingGxsInvites.end()
+                    && pending->second == "{\"type\":\"chess_invite\"}")
+                mPendingGxsInvites.erase(pending);
+        }
+        mNotify->notifyChessRejectedGxs(sender_id);
 
     } else if (type == "player_leave") {
         std::cout << "Chess: Remote GXS player left " << sender_id << std::endl;

--- a/services/p3RetroChess.h
+++ b/services/p3RetroChess.h
@@ -113,6 +113,7 @@ public:
 	void sendGxsInvite(const RsGxsId &toGxsId);
 	bool sendInviteToGxs(const RsGxsId &gxsId) override;
 	void acceptedInviteGxs(const RsGxsId &gxsId);
+	bool rejectedInviteGxs(const RsGxsId &gxsId) override;
 	void clearInviteGxs(const RsGxsId &gxsId) override;
 	bool hasInviteFromGxs(const RsGxsId &gxsId) override;
 	RsGxsId ownGxsIdForPeer(const RsGxsId &gxsId) override;


### PR DESCRIPTION
- Sends {"type":"chess_reject"}.
- Clears the invitation on both sides.
- Shows the sender “Invitation declined.”
- Clears stale notifications and allows retry if sending fails.
- Add contacts list for chess invite